### PR TITLE
Add vault configs, weekly pipeline yaml and re enable secret validation steps in CI

### DIFF
--- a/.vault-config/dotnet-grafana-production.yaml
+++ b/.vault-config/dotnet-grafana-production.yaml
@@ -1,0 +1,21 @@
+storageLocation:
+  type: azure-key-vault
+  parameters:
+    subscription: a4fc5514-21a9-4296-bfaf-5c7ee7fa35d1
+    name: dotnet-grafana
+
+importSecretsFrom: shared/dotnet-grafana-secrets.yaml
+
+secrets:
+  # Used by machine setup scripts during deployment and for the alert system for image storage
+  dotnetgrafana-storage-account-key:
+    type: azure-storage-key
+    parameters:
+      account: dotnetgrafana
+      subscription: a4fc5514-21a9-4296-bfaf-5c7ee7fa35d1
+
+  # Grafana API token with Admin privileges
+  grafana-admin-api-key:
+    type: grafana-api-key
+    parameters:
+      environment: dotnet-eng-grafana.westus2.cloudapp.azure.com

--- a/.vault-config/dotnet-grafana-staging.yaml
+++ b/.vault-config/dotnet-grafana-staging.yaml
@@ -1,0 +1,22 @@
+storageLocation:
+  type: azure-key-vault
+  parameters:
+    subscription: a4fc5514-21a9-4296-bfaf-5c7ee7fa35d1
+    name: dotnet-grafana-staging
+
+importSecretsFrom: shared/dotnet-grafana-secrets.yaml
+
+secrets:
+
+  # Used by machine setup scripts during deployment and for the alert system for image storage
+  dotnetgrafana-storage-account-key:
+    type: azure-storage-key
+    parameters:
+      account: dotnetgrafanastaging
+      subscription: a4fc5514-21a9-4296-bfaf-5c7ee7fa35d1
+
+  # Grafana API token with Admin privileges
+  grafana-admin-api-key:
+    type: grafana-api-key
+    parameters:
+      environment: dotnet-eng-grafana-staging.westus2.cloudapp.azure.com

--- a/.vault-config/dotneteng-status-local.yaml
+++ b/.vault-config/dotneteng-status-local.yaml
@@ -1,0 +1,37 @@
+storageLocation:
+  type: azure-key-vault
+  parameters:
+    subscription: cab65fc3-d077-467d-931f-3932eabf36d3
+    name: dotneteng-status-local
+
+references:
+  helixkv:
+    type: azure-key-vault
+    parameters:
+      subscription: a4fc5514-21a9-4296-bfaf-5c7ee7fa35d1
+      name: helixkv
+
+
+secrets:
+
+  github:
+    type: github-app-secret
+    parameters:
+      hasPrivateKey: true
+      hasWebhookSecret: true
+      hasOAuthSecret: true
+
+  grafana-api-token:
+    type: grafana-api-key
+    parameters:
+      environment: dotnet-eng-grafana-staging.westus2.cloudapp.azure.com
+
+  nethelix-engsrv-kusto-connection-string-ingest:
+    type: kusto-connection-string
+    parameters:
+      adApplication:
+        location: helixkv
+        name: nethelix-staging-kusto-ad-application
+      dataSource: https://ingest-engdata.kusto.windows.net:443
+      additionalParameters: Authority Id=72f988bf-86f1-41af-91ab-2d7cd011db47
+      

--- a/.vault-config/dotneteng-status-prod.yaml
+++ b/.vault-config/dotneteng-status-prod.yaml
@@ -1,0 +1,46 @@
+storageLocation:
+  type: azure-key-vault
+  parameters:
+    subscription: 68672ab8-de0c-40f1-8d1b-ffb20bd62c0f
+    name: dotneteng-status-prod
+
+references:
+  helixkv:
+    type: azure-key-vault
+    parameters:
+      subscription: a4fc5514-21a9-4296-bfaf-5c7ee7fa35d1
+      name: helixkv
+
+keys:
+  dotnet-status-data-protection:
+    type: RSA
+    size: 2048
+
+importSecretsFrom: shared/dotneteng-status-secrets.yaml
+
+secrets:
+  dotnet-status-storage-account:
+    type: azure-storage-connection-string
+    parameters:
+      subscription: 68672ab8-de0c-40f1-8d1b-ffb20bd62c0f
+      account: dotnetengstatusprod
+
+  # Grafana API key with admin privileges
+  grafana-api-token:
+    type: grafana-api-key
+    parameters:
+      environment: dotnet-eng-grafana.westus2.cloudapp.azure.com
+  
+  nethelix-engsrv-kusto-connection-string-ingest:
+    type: kusto-connection-string
+    parameters:
+      adApplication:
+        location: helixkv
+        name: nethelix-prod-kusto-ad-application
+      dataSource: https://ingest-engsrvprod.kusto.windows.net:443
+      additionalParameters: Streaming=true;Authority Id=72f988bf-86f1-41af-91ab-2d7cd011db47
+
+  build-monitor-hook-dotnet-eng-status-token:
+    type: text
+    parameters:
+      description: Generate API token from https://dotneteng-status.azurewebsites.net/ and save it to the service hook with ID 439d5934-8e89-4407-8e31-5b04d58b7854

--- a/.vault-config/dotneteng-status-staging.yaml
+++ b/.vault-config/dotneteng-status-staging.yaml
@@ -1,0 +1,41 @@
+storageLocation:
+  type: azure-key-vault
+  parameters:
+    subscription: cab65fc3-d077-467d-931f-3932eabf36d3
+    name: dotneteng-status-staging
+
+references:
+  helixkv:
+    type: azure-key-vault
+    parameters:
+      subscription: a4fc5514-21a9-4296-bfaf-5c7ee7fa35d1
+      name: helixkv
+
+keys:
+  dotnet-status-data-protection:
+    type: RSA
+    size: 2048
+
+importSecretsFrom: shared/dotneteng-status-secrets.yaml
+
+secrets:
+  dotnet-status-storage-account:
+    type: azure-storage-connection-string
+    parameters:
+      subscription: cab65fc3-d077-467d-931f-3932eabf36d3
+      account: dotnetengstatusstaging
+  
+  # Grafana API key with admin privileges
+  grafana-api-token:
+    type: grafana-api-key
+    parameters:
+      environment: dotnet-eng-grafana-staging.westus2.cloudapp.azure.com
+
+  nethelix-engsrv-kusto-connection-string-ingest:
+    type: kusto-connection-string
+    parameters:
+      adApplication:
+        location: helixkv
+        name: nethelix-staging-kusto-ad-application
+      dataSource: https://ingest-engdata.kusto.windows.net:443
+      additionalParameters: Authority Id=72f988bf-86f1-41af-91ab-2d7cd011db47

--- a/.vault-config/helixkv.yaml
+++ b/.vault-config/helixkv.yaml
@@ -1,0 +1,19 @@
+storageLocation:
+  type: azure-key-vault
+  parameters:
+    subscription: a4fc5514-21a9-4296-bfaf-5c7ee7fa35d1
+    name: helixkv
+
+
+secrets:
+  nethelix-staging-kusto-ad-application:
+    type: ad-application
+
+  nethelix-prod-kusto-ad-application:
+    type: ad-application
+
+  dn-bot-account-redmond:
+    type: domain-account
+    parameters:
+      accountName: dn-bot
+      description: The dn-bot account

--- a/.vault-config/maestroint.yaml
+++ b/.vault-config/maestroint.yaml
@@ -1,0 +1,44 @@
+storageLocation:
+  type: azure-key-vault
+  parameters:
+    subscription: cab65fc3-d077-467d-931f-3932eabf36d3
+    name: maestroint
+
+references:
+  helixkv:
+    type: azure-key-vault
+    parameters:
+      subscription: a4fc5514-21a9-4296-bfaf-5c7ee7fa35d1
+      name: helixkv
+
+keys:
+  data-protection-encryption-key:
+    type: RSA
+    size: 2048
+
+importSecretsFrom: shared/maestro-secrets.yaml
+
+secrets:
+  maestro-storage-account:
+    type: azure-storage-connection-string
+    parameters:
+      subscription: cab65fc3-d077-467d-931f-3932eabf36d3
+      account: maestroint
+
+  nethelix-engsrv-kusto-connection-string-ingest:
+    type: kusto-connection-string
+    parameters:
+      adApplication:
+        location: helixkv
+        name: nethelix-staging-kusto-ad-application
+      dataSource: https://ingest-engdata.kusto.windows.net:443
+      additionalParameters: Streaming=true;Authority Id=72f988bf-86f1-41af-91ab-2d7cd011db47
+
+  nethelix-engsrv-kusto-connection-string-query:
+    type: kusto-connection-string
+    parameters:
+      adApplication:
+        location: helixkv
+        name: nethelix-staging-kusto-ad-application
+      dataSource: https://engdata.kusto.windows.net:443
+      additionalParameters: Authority Id=72f988bf-86f1-41af-91ab-2d7cd011db47

--- a/.vault-config/maestrolocal.yaml
+++ b/.vault-config/maestrolocal.yaml
@@ -1,0 +1,58 @@
+storageLocation:
+  type: azure-key-vault
+  parameters:
+    name: maestrolocal
+    subscription: cab65fc3-d077-467d-931f-3932eabf36d3
+
+references:
+  helixkv:
+    type: azure-key-vault
+    parameters:
+      subscription: a4fc5514-21a9-4296-bfaf-5c7ee7fa35d1
+      name: helixkv
+
+secrets:
+  github:
+    type: github-app-secret
+    parameters:
+      hasPrivateKey: true
+      hasWebhookSecret: false
+      hasOAuthSecret: true
+
+  nethelix-engsrv-kusto-connection-string-ingest:
+    type: kusto-connection-string
+    parameters:
+      adApplication:
+        location: helixkv
+        name: nethelix-staging-kusto-ad-application
+      dataSource: https://ingest-engdata.kusto.windows.net:443
+      additionalParameters: Streaming=true;Authority Id=72f988bf-86f1-41af-91ab-2d7cd011db47
+
+  nethelix-engsrv-kusto-connection-string-query:
+    type: kusto-connection-string
+    parameters:
+      adApplication:
+        location: helixkv
+        name: nethelix-staging-kusto-ad-application
+      dataSource: https://engdata.kusto.windows.net:443
+      additionalParameters: Authority Id=72f988bf-86f1-41af-91ab-2d7cd011db47
+
+  dn-bot-dnceng-build-r:
+    type: azure-devops-access-token
+    parameters:
+      domainAccountName: dn-bot
+      domainAccountSecret:
+        location: helixkv
+        name: dn-bot-account-redmond
+      organizations: dnceng
+      scopes: build
+      
+  dn-bot-dnceng-public-build-r:
+    type: azure-devops-access-token
+    parameters:
+      domainAccountName: dn-bot
+      domainAccountSecret:
+        location: helixkv
+        name: dn-bot-account-redmond
+      organizations: dnceng-public
+      scopes: build

--- a/.vault-config/maestroprod.yaml
+++ b/.vault-config/maestroprod.yaml
@@ -1,0 +1,44 @@
+storageLocation:
+  type: azure-key-vault
+  parameters:
+    subscription: 68672ab8-de0c-40f1-8d1b-ffb20bd62c0f
+    name: maestroprod
+
+references:
+  helixkv:
+    type: azure-key-vault
+    parameters:
+      subscription: a4fc5514-21a9-4296-bfaf-5c7ee7fa35d1
+      name: helixkv
+
+keys:
+  data-protection-encryption-key:
+    type: RSA
+    size: 2048
+
+importSecretsFrom: shared/maestro-secrets.yaml
+
+secrets:
+  maestro-storage-account:
+    type: azure-storage-connection-string
+    parameters:
+      subscription: 68672ab8-de0c-40f1-8d1b-ffb20bd62c0f
+      account: maestroprod1337
+
+  nethelix-engsrv-kusto-connection-string-ingest:
+    type: kusto-connection-string
+    parameters:
+      adApplication:
+        location: helixkv
+        name: nethelix-prod-kusto-ad-application
+      dataSource: https://ingest-engsrvprod.kusto.windows.net:443
+      additionalParameters: Streaming=true;Authority Id=72f988bf-86f1-41af-91ab-2d7cd011db47
+
+  nethelix-engsrv-kusto-connection-string-query:
+    type: kusto-connection-string
+    parameters:
+      adApplication:
+        location: helixkv
+        name: nethelix-prod-kusto-ad-application
+      dataSource: https://engsrvprod.kusto.windows.net:443
+      additionalParameters: Authority Id=72f988bf-86f1-41af-91ab-2d7cd011db47

--- a/.vault-config/shared/dotnet-grafana-secrets.yaml
+++ b/.vault-config/shared/dotnet-grafana-secrets.yaml
@@ -1,0 +1,51 @@
+# API token from https://dotneteng-status{-staging}.azurewebsites.net/
+# Token should be named "dotent-grafana{-staging}/dotnet-build-bot-dotnet-eng-status-token"
+# Generated using the dotnet-build-bot account. 
+dotnet-build-bot-dotnet-eng-status-token:
+  type: text
+  parameters:
+    description: Generate API token from https://dotneteng-status{-staging}.azurewebsites.net/
+
+# Secrets for GitHub OAuth app owned by user dotnet-gh-app-bot
+#  - "Dotnet Engineering Grafana Monitoring"
+#  - "Dotnet Engineering Grafana Monitoring (staging)"
+dotnet-grafana-github:
+  type: github-oauth-secret
+  parameters:
+    hasPrivateKey: false
+    hasWebHookSecret: false
+    hasAppSecret: true
+
+# Composite value with dotnet-build-bot-dotnet-eng-status-token
+dotneteng-status-auth-header:
+  type: text
+  parameters:
+    description: "Value must be \"Bearer <value of dotnet-build-bot-dotnet-eng-status-token>\""
+
+# Fixed value set by Teams Incoming Hook plugin; no rotation, but should be kept secret.
+fr-bot-notifications-teams-notification-url:
+  type: text
+  parameters:
+    description: Do not rotate
+
+# helix-grafana Service Principal, client ID a2541735-8225-40af-9c8a-2ae233203739
+helix-grafana:
+  type: ad-application
+
+# "Engineering Services" Service Principal. Client ID 2bdfceef-194a-4775-99d9-b5575c77bc6b. Used by deployment.
+engineering-services:
+  type: ad-application
+
+# Grafana Admin user password
+grafana-admin-password:
+  type: text
+  parameters: 
+    description: Log in as a Server Administrator, then use the Users control panel to set the Admin user password.
+
+# Used by Grafana to encrypt data source secrets at-rest; do not rotate lest data become un-decryptable.
+# To rotate, (1) set new key, (2) delete all data sources from Grafana, (3) deploy datasources from version control
+# See https://dev.azure.com/dnceng/internal/_wiki/wikis/DNCEng%20Services%20Wiki/182/Alerting?anchor=how-to%3A-export-the-configuration
+grafana-aes-256-secret-key:
+  type: text
+  parameters:
+    description: Do not rotate

--- a/.vault-config/shared/dotneteng-status-secrets.yaml
+++ b/.vault-config/shared/dotneteng-status-secrets.yaml
@@ -1,0 +1,69 @@
+github:
+  type: github-app-secret
+  parameters:
+    hasPrivateKey: true
+    hasWebhookSecret: true
+    hasOAuthSecret: true
+  
+token-table-sas-uri:
+  type: azure-storage-table-sas-uri
+  parameters:
+    connectionString: dotnet-status-storage-account
+    permissions: rau
+    table: tokens
+
+deployment-table-sas-uri:
+  type: azure-storage-table-sas-uri
+  parameters:
+    connectionString: dotnet-status-storage-account
+    permissions: rau
+    table: deployments
+
+data-protection-key-file-uri:
+  type: azure-storage-blob-sas-uri
+  parameters:
+    connectionString: dotnet-status-storage-account
+    permissions: racwd
+    container: site
+    blob: keys.xml
+
+fr-teams-channel-webhook-url:
+  type: text
+  parameters:
+    description: The teams "incoming webhook" connector url for the FR issue notification channel
+
+app-insights-instrumentation-key:
+  type: text
+  parameters:
+    description: The instrumentation key for application insights. Go to the Azure resource for application insights -> Configure -> Properties -> Get the instrumentation key
+
+dn-bot-dnceng-build-rw-code-rw-release-rw:
+  type: azure-devops-access-token
+  parameters:
+    organizations: dnceng
+    scopes: build_execute code_write release_execute
+    domainAccountName: dn-bot
+    domainAccountSecret:
+      name: dn-bot-account-redmond
+      location: helixkv
+
+dn-bot-dnceng-workitems-rw:
+  type: azure-devops-access-token
+  parameters:
+    organizations: dnceng
+    scopes: work_write
+    domainAccountName: dn-bot
+    domainAccountSecret:
+      name: dn-bot-account-redmond
+      location: helixkv
+
+dn-bot-dnceng-build-r-code-r-project-r-profile-r:
+  type: azure-devops-access-token
+  parameters:
+    organizations: dnceng
+    scopes: build code project profile
+    requiredScopes: Build (Read) Code (Read) Project (Read) Profile (Read)
+    domainAccountName: dn-bot
+    domainAccountSecret:
+      name: dn-bot-account-redmond
+      location: helixkv

--- a/.vault-config/shared/maestro-secrets.yaml
+++ b/.vault-config/shared/maestro-secrets.yaml
@@ -1,0 +1,33 @@
+github:
+  type: github-app-secret
+  parameters:
+    hasPrivateKey: true
+    hasWebhookSecret: true
+    hasOAuthSecret: true
+
+health-report-table-sas-uri:
+  type: azure-storage-table-sas-uri
+  parameters:
+    connectionString: maestro-storage-account
+    permissions: raud
+    table: healthreport
+
+dn-bot-dnceng-build-r:
+  type: azure-devops-access-token
+  parameters:
+    domainAccountName: dn-bot
+    domainAccountSecret:
+      location: helixkv
+      name: dn-bot-account-redmond
+    organizations: dnceng
+    scopes: build
+    
+dn-bot-dnceng-public-build-r:
+  type: azure-devops-access-token
+  parameters:
+    domainAccountName: dn-bot
+    domainAccountSecret:
+      location: helixkv
+      name: dn-bot-account-redmond
+    organizations: dnceng-public
+    scopes: build

--- a/azure-pipelines-weekly.yml
+++ b/azure-pipelines-weekly.yml
@@ -32,4 +32,4 @@ stages:
           scriptType: ps
           scriptLocation: inlineScript
           inlineScript: |
-            Get-ChildItem .vault-config/*.yaml |% { dotnet run --project src/Microsoft.DncEng.SecretManager/Microsoft.DncEng.SecretManager -- synchronize $_}
+            Get-ChildItem .vault-config/*.yaml |% { dotnet run --project src/SecretManager/Microsoft.DncEng.SecretManager -- synchronize $_}

--- a/azure-pipelines-weekly.yml
+++ b/azure-pipelines-weekly.yml
@@ -1,0 +1,35 @@
+trigger: none
+
+schedules:
+- cron: 0 12 * * 1
+  displayName: Weekly Monday build
+  branches:
+    include:
+    - main
+  always: true
+
+name: $(Date:yyyMMdd)$(Rev:rr)
+
+stages:
+  - stage: SynchronizeSecrets
+    jobs:
+    - job: Synchronize
+      pool: 
+        name: NetCore1ESPool-Internal-NoMSI
+        demands: ImageOverride -equals 1es-windows-2022
+      steps:
+      - task: UseDotNet@2
+        displayName: Install Correct .NET Version
+        inputs:
+          useGlobalJson: true
+
+      # - script: dotnet build
+      #   workingDirectory: src/Microsoft.DncEng.SecretManager
+
+      - task: AzureCLI@2
+        inputs:
+          azureSubscription: DotNet Eng Services Secret Manager
+          scriptType: ps
+          scriptLocation: inlineScript
+          inlineScript: |
+            Get-ChildItem .vault-config/*.yaml |% { dotnet run --project src/Microsoft.DncEng.SecretManager/Microsoft.DncEng.SecretManager -- synchronize $_}

--- a/azure-pipelines-weekly.yml
+++ b/azure-pipelines-weekly.yml
@@ -23,9 +23,6 @@ stages:
         inputs:
           useGlobalJson: true
 
-      # - script: dotnet build
-      #   workingDirectory: src/Microsoft.DncEng.SecretManager
-
       - task: AzureCLI@2
         inputs:
           azureSubscription: DotNet Eng Services Secret Manager

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -158,7 +158,7 @@ stages:
              $manifestArgs += @("-m", $_.FullName)
            }
            dotnet run --project src/SecretManager/Microsoft.DncEng.SecretManager -- validate-all -b src @manifestArgs
-         displayName: Verify Secret Usages
+          displayName: Verify Secret Usages
 
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -152,14 +152,13 @@ stages:
           displayName: Build / Publish
           condition: succeeded()
         
-        # TODO https://github.com/dotnet/arcade/issues/13373
-        #- powershell: |
-        #    $manifestArgs = @()
-        #    Get-ChildItem .vault-config/*.yaml |% {
-        #      $manifestArgs += @("-m", $_.FullName)
-        #    }
-        #    dotnet run --project src/Microsoft.DncEng.SecretManager -- validate-all -b src @manifestArgs
-        #  displayName: Verify Secret Usages
+        - powershell: |
+           $manifestArgs = @()
+           Get-ChildItem .vault-config/*.yaml |% {
+             $manifestArgs += @("-m", $_.FullName)
+           }
+           dotnet run --project src/SecretManager/Microsoft.DncEng.SecretManager -- validate-all -b src @manifestArgs
+         displayName: Verify Secret Usages
 
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
 

--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -15,39 +15,34 @@ parameters:
   # secret-manager-scenario-tests-client-secret
 
 stages:
-# TODO https://github.com/dotnet/arcade/issues/13373
-# - stage: ValidateSecrets
-#   dependsOn:
-#   - build
-#   jobs:
-#   - job: ValidateSecrets
-#     pool: 
-#       name: NetCore1ESPool-Internal-NoMSI
-#       demands: ImageOverride -equals 1es-windows-2019
-#     steps:
-#     - task: UseDotNet@2
-#       displayName: Install Correct .NET Version
-#       inputs:
-#         useGlobalJson: true
+- stage: ValidateSecrets
+  dependsOn:
+  - build
+  jobs:
+  - job: ValidateSecrets
+    pool: 
+      name: NetCore1ESPool-Internal-NoMSI
+      demands: ImageOverride -equals 1es-windows-2019
+    steps:
+    - task: UseDotNet@2
+      displayName: Install Correct .NET Version
+      inputs:
+        useGlobalJson: true
 
-#     - script: dotnet build
-#       workingDirectory: src/Microsoft.DncEng.SecretManager
-
-#     - task: AzureCLI@2
-#       inputs:
-#         azureSubscription: DotNet Eng Services Secret Manager
-#         scriptType: ps
-#         scriptLocation: inlineScript
-#         inlineScript: |
-#           Get-ChildItem .vault-config/*.yaml |% { dotnet run --project src/Microsoft.DncEng.SecretManager -- synchronize --verify-only $_}
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: DotNet Eng Services Secret Manager
+        scriptType: ps
+        scriptLocation: inlineScript
+        inlineScript: |
+          Get-ChildItem .vault-config/*.yaml |% { dotnet run --project src/SecretManager/Microsoft.DncEng.SecretManager -- synchronize --verify-only $_}
 
 - stage: approval
   pool: server
   dependsOn:
   - build
   - Validate
-  # TODO https://github.com/dotnet/arcade/issues/13373
-  #- ValidateSecrets
+  - ValidateSecrets
   - publish_using_darc
   jobs:
   - deployment: approval


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/13373
This PR adds the weekly pipeline yaml and the .vault configs that it needs.
Only secrets that are used by the pipeline have been transferred.
List of secrets that were **not** transferred:

Helixkv.yaml
- dnb2-bot-account-redmond
- dn-dependabot-account-redmond
- dotnet-mc-bot-account

maestro-secrets.yaml
- data-protection-key-file-uri
- maestro-memory-dumps-container-sas-uri
- prod-maestro-token
- dn-bot-dnceng-build-rw-code-rw-release-rw
- dn-bot-devdiv-build-rw-code-rw-release-rw
- dn-bot-domoreexp-build-rw-code-rw-release-rw
- dn-bot-dnceng-packaging-rwm

maestroint.yaml
- build-asset-registry-admin-connection-string
- build-asset-registry-sql-connection-string

maestrolocal.yaml
- prod-maestro-token
- dn-bot-dnceng-build-rw-code-rw-release-rw
- dn-bot-devdiv-build-rw-code-rw-release-rw
- dn-bot-domoreexp-build-rw-code-rw-release-rw
- dn-bot-dnceng-packaging-rwm

maestroprod.yaml
- build-asset-registry-admin-connection-string
- build-asset-registry-sql-connection-string