### PR TITLE
Fix yaml indentation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -158,7 +158,7 @@ stages:
               $manifestArgs += @("-m", $_.FullName)
             }
             dotnet run --project src/SecretManager/Microsoft.DncEng.SecretManager -- validate-all -b src @manifestArgs
-         displayName: Verify Secret Usages
+          displayName: Verify Secret Usages
 
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -153,11 +153,11 @@ stages:
           condition: succeeded()
         
         - powershell: |
-           $manifestArgs = @()
-           Get-ChildItem .vault-config/*.yaml |% {
-             $manifestArgs += @("-m", $_.FullName)
-           }
-           dotnet run --project src/SecretManager/Microsoft.DncEng.SecretManager -- validate-all -b src @manifestArgs
+            $manifestArgs = @()
+            Get-ChildItem .vault-config/*.yaml |% {
+              $manifestArgs += @("-m", $_.FullName)
+            }
+            dotnet run --project src/SecretManager/Microsoft.DncEng.SecretManager -- validate-all -b src @manifestArgs
          displayName: Verify Secret Usages
 
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/13373
In the previous PR https://github.com/dotnet/dnceng/pull/12, the yaml had these errors, and the pipeline wasn't able to trigger. For some reason that did not appear int the GitHub view, it was saying that all checks are successful.