### PR TITLE
Add dnceng to rollout scorecards; scorecards should be added to dncen…

### DIFF
--- a/.github/ISSUE_TEMPLATE/default-dnceng-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/default-dnceng-issue-template.md
@@ -1,0 +1,20 @@
+---
+name: Default Dnceng Issue Template
+about: Used by Dnceng as the default issue template
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!-- Write your issue description below. -->
+
+<!-- DO NOT DELETE -->
+<!-- For internal use only; put release notes here. -->
+<!-- For guidance on writing good release notes, please see documentation here: https://dev.azure.com/dnceng/internal/_wiki/wikis/DNCEng%20Services%20Wiki/983/ReleaseNotesGuidance -->
+<!-- Additionally, please specify the note category below. -->
+### Release Note Category
+- [ ] Feature changes/additions 
+- [ ] Bug fixes
+- [ ] Internal Infrastructure Improvements
+### Release Note Description

--- a/src/RolloutScorer/RolloutScorer/Commands.cs
+++ b/src/RolloutScorer/RolloutScorer/Commands.cs
@@ -161,7 +161,7 @@ public class UploadCommand : Command
 {
     public UploadCommand() : base("upload", "The upload command takes a series of inline arguments which specify the" +
                                             "locations of the scorecard CSV files to upload. Each of these files will be combined into a single scorecard document.\n\n" +
-                                            "\"Uploading\" the file here means making a PR to arcade containing adding the scorecard to '/Documentation/Rollout-Scorecards/'" +
+                                            "\"Uploading\" the file here means making a PR to dnceng containing adding the scorecard to '/Documentation/Rollout-Scorecards/'" +
                                             "and placing the data in Kusto which backs a PowerBI dashboard.\n\n" +
                                             "usage: RolloutScorer upload [CSV_FILE_1] [CSV_FILE_2] ...\n")
     {

--- a/src/RolloutScorer/RolloutScorer/Commands.cs
+++ b/src/RolloutScorer/RolloutScorer/Commands.cs
@@ -161,7 +161,7 @@ public class UploadCommand : Command
 {
     public UploadCommand() : base("upload", "The upload command takes a series of inline arguments which specify the" +
                                             "locations of the scorecard CSV files to upload. Each of these files will be combined into a single scorecard document.\n\n" +
-                                            "\"Uploading\" the file here means making a PR to dnceng containing adding the scorecard to '/Documentation/Rollout-Scorecards/'" +
+                                            "\"Uploading\" the file here means making a PR to dnceng containing adding the scorecard to '/Documentation/TeamProcess/Rollout-Scorecards/'" +
                                             "and placing the data in Kusto which backs a PowerBI dashboard.\n\n" +
                                             "usage: RolloutScorer upload [CSV_FILE_1] [CSV_FILE_2] ...\n")
     {

--- a/src/RolloutScorer/RolloutScorer/StandardConfig.cs
+++ b/src/RolloutScorer/RolloutScorer/StandardConfig.cs
@@ -11,7 +11,7 @@ public static class StandardConfig
             new RepoConfig
             {
                 Repo = "dotnet-helix-service",
-                BuildDefinitionIds = new List<string> { "620", "697" },
+                BuildDefinitionIds = new List<string> { "620" },
                 AzdoInstance = "dnceng",
                 GithubIssueLabel = "Rollout Helix",
                 MaxAllowedTimeInMinutes = 360,
@@ -29,9 +29,18 @@ public static class StandardConfig
             new RepoConfig
             {
                 Repo = "arcade-services",
-                BuildDefinitionIds = new List<string> { "252", "728" },
+                BuildDefinitionIds = new List<string> { "252" },
                 AzdoInstance = "dnceng",
                 GithubIssueLabel = "Rollout Arcade-Services",
+                MaxAllowedTimeInMinutes = 360,
+                ExcludeStages = new List<string> { "Post-Deployment", "Validate deployment" },
+            },
+            new RepoConfig
+            {
+                Repo = "dnceng",
+                BuildDefinitionIds = new List<string> { "1254" },
+                AzdoInstance = "dnceng",
+                GithubIssueLabel = "Rollout dnceng",
                 MaxAllowedTimeInMinutes = 360,
                 ExcludeStages = new List<string> { "Post-Deployment", "Validate deployment" },
             },
@@ -58,7 +67,7 @@ public static class StandardConfig
         GithubConfig = new GithubConfig
         {
             ScorecardsGithubOrg = "dotnet",
-            ScorecardsGithubRepo = "arcade",
+            ScorecardsGithubRepo = "dnceng",
             ScorecardsDirectoryPath = "Documentation/TeamProcess/Rollout-Scorecards/",
         },
     };


### PR DESCRIPTION
Things done: 
- Added dnceng rollout to be tracked by rollout scorer
- Removed references to pipelines that do not exist anymore
- Updated references to arcade to reference dnceng (including where the scorecards are published to)

Issues: 
- https://github.com/dotnet/arcade/issues/13584
- https://github.com/dotnet/arcade/issues/13610