### PR TITLE
DotNetStatus config changes

### DIFF
--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Production.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Production.json
@@ -3,7 +3,7 @@
   "KeyVaultUri": "https://DotNetEng-Status-Prod.vault.azure.net/",
   "GitHub": {
     "Organization": "dotnet",
-    "Repository": "arcade",
+    "Repository": "dnceng",
     "NotificationTarget": "dotnet/dnceng",
     "AlertLabels": [ "First Responder", "Critical" ],
     "EnvironmentLabels": [ "Production" ],

--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Staging.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Staging.json
@@ -3,7 +3,7 @@
   "KeyVaultUri": "https://DotNetEng-Status-Staging.vault.azure.net/",
   "GitHub": {
     "Organization": "dotnet",
-    "Repository": "arcade",
+    "Repository": "dnceng",
     "NotificationTarget": "dotnet/dnceng",
     "AlertLabels": [ "First Responder" ],
     "EnvironmentLabels": [ "Staging" ],

--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
@@ -187,8 +187,7 @@
   },
   "IssueMentionForwarding": {
     "WatchedTeam": "dotnet/dnceng",
-    "IgnoreRepos": [
-    ],
+    "IgnoreRepos": [ "arcade", "dnceng" ],
     "TeamsWebHookUri": "[vault(fr-teams-channel-webhook-url)]"
   }
 }

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/GitHubHookController.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/GitHubHookController.cs
@@ -317,7 +317,7 @@ For help filling out this form, see the [Root Cause Analysis](https://dev.azure.
                 triggeringLabel = names.FirstOrDefault();
                 if (names.Count == 0)
                 {
-                    _logger.LogTrace("Issue {repo}/{number} is closed by has no RCA label, taking no RCA action", data.Repository.Name, data.Issue.Number);
+                    _logger.LogTrace("Issue {repo}/{number} is closed but has no RCA label, taking no RCA action", data.Repository.Name, data.Issue.Number);
                     return false;
                 }
 


### PR DESCRIPTION
- Updated the config in DotNetStatus to open new issues in dotnet/dnceng. This should affect functionality for RCAs, Grafana, and Timeline issues. 
- Added dotnet/dnceng and dotnet/arcade to the ignore repos for issue forwarding for the FR Bot Notifications channel to reduce noise until migrations are completed. 
- Fixed some wording.

Related issues: 
- https://github.com/dotnet/arcade/issues/13590
- https://github.com/dotnet/arcade/issues/13580