### PR TITLE
Removing Arcade Services from Rollout Scorer

### DIFF
--- a/src/RolloutScorer/RolloutScorer/StandardConfig.cs
+++ b/src/RolloutScorer/RolloutScorer/StandardConfig.cs
@@ -28,15 +28,6 @@ public static class StandardConfig
             },
             new RepoConfig
             {
-                Repo = "arcade-services",
-                BuildDefinitionIds = new List<string> { "252" },
-                AzdoInstance = "dnceng",
-                GithubIssueLabel = "Rollout Arcade-Services",
-                MaxAllowedTimeInMinutes = 360,
-                ExcludeStages = new List<string> { "Post-Deployment", "Validate deployment" },
-            },
-            new RepoConfig
-            {
                 Repo = "dnceng",
                 BuildDefinitionIds = new List<string> { "1254" },
                 AzdoInstance = "dnceng",


### PR DESCRIPTION
Changes made to the Arcade Services deployment script will not contain things (e.g., timing) that's needed for Rollout Scorer to perform. Removing Arcade Services from Rollout Scorer config so that it will not be looked for when attempting to generate the scorecard. 

Related to work done for https://github.com/dotnet/arcade-services/issues/2296