### PR TITLE
Secret manager rotating bot account fix

### DIFF
--- a/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/GitHubBotAccount.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/GitHubBotAccount.cs
@@ -53,7 +53,7 @@ public class GitHubBotAccount : GitHubAccountInteractiveSecretType<GitHubBotAcco
         var secret = await context.GetSecretValue(new SecretReference(context.SecretName + GitHubSecretSuffix));
 
         const string helpUrl = "https://github.com/settings/security";
-        await ShowGitHubLoginInformation(helpUrl, parameters.Name, secret, password);
+        await ShowGitHubLoginInformation(helpUrl, parameters.Name, password, secret);
 
         var rollPassword = await Console.ConfirmAsync("Do you want to roll bot's password (yes/no): ");
         if (rollPassword)


### PR DESCRIPTION
I found this when trying to add a new bot account to a config file. I had a error because the values for the account password and the one-time-password were switched. I believe it's a small bug in the bot account secret type

issue: https://github.com/dotnet/dnceng/issues/210
