### PR TITLE
Update auto-label assignments for the new view of Ops

### DIFF
--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
@@ -56,19 +56,19 @@
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\arcade\\dotnet-arcade-weekly",
           "Branches": [ "main" ],
-          "IssuesId": "dotnet-dnceng-frops"
+          "IssuesId": "dotnet-dnceng-ops"
         },
         {
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\helix-service\\dotnet-helix-service-weekly",
           "Branches": [ "main" ],
-          "IssuesId": "dotnet-dnceng-frops"
+          "IssuesId": "dotnet-dnceng-ops"
         },
         {
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\helix-machines\\dotnet-helix-machines-weekly",
           "Branches": [ "main" ],
-          "IssuesId": "dotnet-dnceng-frops"
+          "IssuesId": "dotnet-dnceng-ops"
         },
         {
           "Project": "internal",
@@ -128,7 +128,7 @@
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\dncneg\\dotnet-dnceng-weekly",
           "Branches": [ "main" ],
-          "IssuesId": "dotnet-dnceng-frops"
+          "IssuesId": "dotnet-dnceng-ops"
         }
       ]
     },
@@ -146,10 +146,10 @@
         "Labels": [ "Build Failed", "First Responder" ]
       },
       {
-        "Id": "dotnet-dnceng-frops",
+        "Id": "dotnet-dnceng-ops",
         "Owner": "dotnet",
         "Name": "dnceng",
-        "Labels": [ "Build Failed", "FROps" ]
+        "Labels": [ "Build Failed", "Ops - Service Maintenance" ]
       },
       {
         "Id": "dotnet-aspnetcore-infra",


### PR DESCRIPTION
Resolves [dotnet/dnceng#468](https://github.com/dotnet/dnceng/issues/468).

Update Build Monitor labelling to reflect the latest view of Ops.