### PR TITLE
[Hotfix] Use the 1es-windows-2022 image instead of 2019 for secret validation

### DIFF
--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -22,7 +22,7 @@ stages:
   - job: ValidateSecrets
     pool: 
       name: NetCore1ESPool-Internal-NoMSI
-      demands: ImageOverride -equals 1es-windows-2019
+      demands: ImageOverride -equals 1es-windows-2022
     steps:
     - task: UseDotNet@2
       displayName: Install Correct .NET Version


### PR DESCRIPTION
This should fix https://github.com/dotnet/dnceng/issues/740

I Validated that this fixes the stage by running this build https://dev.azure.com/dnceng/internal/_build/results?buildId=2256263&view=results which shows the different outcomes of running in the 2022 image versus the 2019 image.


(Main builds are also broken, but I'm focusing on the rollout right now, and I'll let this merge back to fix main) 