### PR TITLE
Fix auth in Grafana dashboard publishing

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -88,7 +88,7 @@
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="7.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="7.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="7.0.1" />
     <PackageVersion Include="WindowsAzure.Storage" Version="9.3.3" />
     <PackageVersion Include="YamlDotNet" Version="9.1.4" />
     <PackageVersion Include="YamlDotNet.Signed" Version="5.3.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -88,6 +88,7 @@
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="7.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="7.0.0" />
     <PackageVersion Include="WindowsAzure.Storage" Version="9.3.3" />
     <PackageVersion Include="YamlDotNet" Version="9.1.4" />
     <PackageVersion Include="YamlDotNet.Signed" Version="5.3.0" />

--- a/src/Monitoring/Sdk/Microsoft.DotNet.Monitoring.Sdk.csproj
+++ b/src/Monitoring/Sdk/Microsoft.DotNet.Monitoring.Sdk.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.Net.Http" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
   <Import Project="$(RepoRoot)eng\BuildTask.targets" />
 </Project>

--- a/src/SecretManager/Microsoft.DncEng.SecretManager.ScenarioTests/ScenarioTestsBase.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager.ScenarioTests/ScenarioTestsBase.cs
@@ -23,8 +23,8 @@ namespace Microsoft.DncEng.SecretManager.Tests
         protected const string KeyVaultName = "SecretManagerTestsKv";
 
         // Token credentials that first try to get credentials from Azure CLI, then fall back to the default
-        private readonly TokenCredential _tokenCredential = new AzureCliCredential(
-            new AzureCliCredentialOptions
+        private readonly TokenCredential _tokenCredential =
+            new DefaultAzureCredential(new DefaultAzureCredentialOptions
             {
                 TenantId = ConfigurationConstants.MsftAdTenantId,
             })

--- a/src/SecretManager/Microsoft.DncEng.SecretManager/Commands/SynchronizeCommand.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/Commands/SynchronizeCommand.cs
@@ -282,7 +282,7 @@ public class SynchronizeCommand : Command
         }
         catch (Exception ex)
         {
-            _console.LogError($"Unhandled Exception: {ex.Message}");
+            _console.LogError($"Unhandled Exception: {ex}");
             throw new FailWithExitCodeException(-1);
         }
     }


### PR DESCRIPTION
Tested locally and it works. The key bit was the missing `JsonEncode` method so we're bringing the Json.Text library in explicitly

https://github.com/dotnet/dnceng/issues/765