### PR TITLE
dotneteng-status fixups for auth failures

### DIFF
--- a/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/AlertHookController.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/AlertHookController.cs
@@ -60,6 +60,8 @@ public class AlertHookController : ControllerBase
             case "no_data":
                 await OpenNewNotificationAsync(notification);
                 break;
+            default:
+                return BadRequest();
         }
 
         return NoContent();

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Models/GrafanaNotification.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Models/GrafanaNotification.cs
@@ -9,7 +9,7 @@ namespace DotNet.Status.Web.Models;
 public class GrafanaNotification
 {
     public string Title { get; set; }
-    public int RuleId { get; set; }
+    public ulong RuleId { get; set; }
     public string RuleName { get; set; }
     public string RuleUrl { get; set; }
     public string State { get; set; }


### PR DESCRIPTION
Some small changes to try to improve site failures due to an apparent authentication problem in [dotnet/dnceng#849](https://github.com/dotnet/dnceng/issues/849).

- Return 400 if the Grafana notification is at all not understood
- Allow RuleId in the notification payload to be much bigger. This should allow the "Test" button on the Grafana Notification screen to work (allowing it to be a real end-to-end test)