### PR TITLE
Clean up setup-grafana cleanup slightly

### DIFF
--- a/grafana-setup.yml
+++ b/grafana-setup.yml
@@ -22,7 +22,7 @@ stages:
 - stage: SynchronizeSecrets
   jobs:
   - job: Synchronize
-    pool: 
+    pool:
       name: NetCore1ESPool-Internal-NoMSI
       demands: ImageOverride -equals 1es-windows-2019
     steps:
@@ -65,7 +65,7 @@ stages:
       jobs:
       - job: Windows_NT
         timeoutInMinutes: 90
-        pool: 
+        pool:
           name: NetCore1ESPool-Internal-NoMSI
           demands: ImageOverride -equals 1es-windows-2019
 
@@ -80,7 +80,7 @@ stages:
             if ($env:GrafanaEnvironment -ne "staging" -and $env:GrafanaEnvironment -ne "production") { Write-Host "GrafanaEnvironment must be 'staging' or 'production'"; exit 1}
             Write-Host "All required variables defined"
           displayName: Ensure variables defined
-        
+
         - task: ArchiveFiles@2
           displayName: Create grafana-init archive
           inputs:
@@ -100,12 +100,12 @@ stages:
             blobPrefix: grafana-init-$(Build.BuildNumber)
             destination: azureBlob
             outputStorageUri: UploadedUri
-        
+
         - task: AzureCLI@2
           displayName: Execute grafana-init/setup.sh on VM
           inputs:
             azureSubscription: DncEng-VSTS
-            scriptType: ps
+            scriptType: pscore
             scriptLocation: inlineScript
             inlineScript: >-
               az vm run-command invoke
@@ -121,7 +121,5 @@ stages:
               sudo bash ./setup.sh -b '$(GrafanaBinPath)' -d '$(GrafanaDomain)' --$(GrafanaEnvironment)
               "
               | Tee-Object -variable cmdoutput
-              | findstr /c:"SETUP_EXIT_CODE=0"
-              | Out-Null;
-              $cmdoutput |% {$_ -replace "\\n","`n->  "} |% {$_ -replace "\\",""} | Write-Host;
-              $LASTEXITCODE
+              |% {$_ -replace "\\n","`n->  "} |% {$_ -replace "\\",""} | Write-Host;
+              select-string -inputObject $cmdoutput -pattern "SETUP_EXIT_CODE=0" -quiet -simpleMatch || exit 1

--- a/src/Monitoring/grafana-init/setup.sh
+++ b/src/Monitoring/grafana-init/setup.sh
@@ -96,11 +96,6 @@ fi
 
 export DEBIAN_FRONTEND=noninteractive
 
-# This is the grafana package repo that allos us to apt-get grafana
-# If we don't trust grafana.com, we're in hot water already, so this is fine
-wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
-add-apt-repository "deb https://packages.grafana.com/oss/deb stable main"
-
 # Before
 df --human-readable --inodes
 df --human-readable
@@ -109,11 +104,17 @@ df --human-readable
 apt-get autoremove --yes
 apt-get autoclean --yes
 apt-get clean --yes
-apt-get install --fix-broken --yes
+apt-get check --yes
 
 # After
 df --human-readable --inodes
 df --human-readable
+du --human-readable --max-depth=2 --threshold=500M /tmp /var
+
+# This is the grafana package repo that allos us to apt-get grafana
+# If we don't trust grafana.com, we're in hot water already, so this is fine
+wget -q -O - https://packages.grafana.com/gpg.key | apt-key add -
+add-apt-repository "deb https://packages.grafana.com/oss/deb stable main"
 
 # Find latest available packages then install pip and grafana packages.
 apt-get update
@@ -170,4 +171,3 @@ systemctl daemon-reload
 systemctl enable grafana-server
 systemctl restart grafana-server
 echo "SETUP_EXIT_CODE=${EXIT_CODE}"
-


### PR DESCRIPTION
- see https://github.com/dotnet/dnceng/issues/1148
- do cleanup before initial download in setup.sh
- just `apt-get check` instead of `apt-get install --fix-broken`
  - fixing broken packages is not commonly necessary
- also display /tmp and /var disk usage
- nit: don't use `findstr` in a PowerShell script
  - use `pscore` b/c that supports the `||` operator
  - a small part of https://github.com/dotnet/dnceng/issues/967