### PR TITLE
fix build monitor configuration for weekly builds

### DIFF
--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
@@ -56,19 +56,19 @@
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\arcade\\dotnet-arcade-weekly",
           "Branches": [ "main" ],
-          "IssuesId": "dotnet-dnceng-frops"
+          "IssuesId": "dotnet-dnceng-first-responder"
         },
         {
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\helix-service\\dotnet-helix-service-weekly",
           "Branches": [ "main" ],
-          "IssuesId": "dotnet-dnceng-frops"
+          "IssuesId": "dotnet-dnceng-first-responder"
         },
         {
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\helix-machines\\dotnet-helix-machines-weekly",
           "Branches": [ "main" ],
-          "IssuesId": "dotnet-dnceng-frops"
+          "IssuesId": "dotnet-dnceng-first-responder"
         },
         {
           "Project": "internal",
@@ -128,7 +128,7 @@
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\dncneg\\dotnet-dnceng-weekly",
           "Branches": [ "main" ],
-          "IssuesId": "dotnet-dnceng-frops"
+          "IssuesId": "dotnet-dnceng-first-responder"
         }
       ]
     },
@@ -144,12 +144,6 @@
         "Owner": "dotnet",
         "Name": "dnceng",
         "Labels": [ "Build Failed", "First Responder" ]
-      },
-      {
-        "Id": "dotnet-dnceng-frops",
-        "Owner": "dotnet",
-        "Name": "dnceng",
-        "Labels": [ "Build Failed", "FROps" ]
       },
       {
         "Id": "dotnet-aspnetcore-infra",


### PR DESCRIPTION
https://github.com/dotnet/dnceng/issues/1368

This makes it so weekly builds get tagged for First responders to fix. It also removes the FRops sections, as we no longer use that label. 