### PR TITLE
Add simple service-connection type for Secret manager

### DIFF
--- a/src/SecretManager/Microsoft.DncEng.SecretManager/Readme.md
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/Readme.md
@@ -407,3 +407,18 @@ type: base64-encoder
 parameters:
   secret: SecretReference to another secret
 ```
+
+### Service Connection
+This type is designed help manage secrets backing Azure DevOps service connections. 
+
+Secret manager does not store the actual secret in the vault. The Key Vault entry is used only to track rotation.
+
+```yaml
+type: service-connection
+parameters:
+  description: This service connection is for doin' stuff
+  organization: dnceng
+  project: internal
+  id: 02878e8e-af59-4dad-96c1-341e4a1c0524
+  name: .NET Engineering Deployment Notification - Production
+```

--- a/src/SecretManager/Microsoft.DncEng.SecretManager/Readme.md
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/Readme.md
@@ -409,7 +409,7 @@ parameters:
 ```
 
 ### Service Connection
-This type is designed help manage secrets backing Azure DevOps service connections. 
+This type is designed to help manage secrets backing Azure DevOps service connections. 
 
 Secret manager does not store the actual secret in the vault. The Key Vault entry is used only to track rotation.
 

--- a/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/ServiceConnectionSecretType.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/ServiceConnectionSecretType.cs
@@ -16,7 +16,7 @@ public class ServiceConnectionSecretType : SecretType<ServiceConnectionSecretTyp
         Service Connections have no standard way to rotate their tokens. Please follow instructions 
         in the DNCEng Internal Wiki at:
         
-        > https://dev.azure.com/dnceng/internal/_wiki/wikis/DNCEng%20Services%20Wiki/1157/Generic-Service-Connections.
+        > https://dev.azure.com/dnceng/internal/_wiki/wikis/DNCEng%20Services%20Wiki/1157
 
         Direct link to this service connection in the portal: 
         

--- a/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/ServiceConnectionSecretType.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/ServiceConnectionSecretType.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DncEng.CommandLineLib;
+using Microsoft.VisualStudio.Services.Security;
+
+namespace Microsoft.DncEng.SecretManager.SecretTypes;
+
+[Name("service-connection")]
+public class ServiceConnectionSecretType : SecretType<ServiceConnectionSecretType.Parameters>
+{
+    private readonly IConsole _console;
+
+    private const string _helpMessage = """
+        Service Connections have no standard way to rotate their tokens. Please follow instructions 
+        in the DNCEng Internal Wiki at:
+        
+        > https://dev.azure.com/dnceng/internal/_wiki/wikis/DNCEng%20Services%20Wiki/1157/Generic-Service-Connections.
+
+        Direct link to this service connection in the portal: 
+        
+        > https://dev.azure.com/{0}/{1}/_settings/adminservices?resourceId={2}
+
+        """;
+
+    public class Parameters
+    {
+        public string Description { get; set; }
+        public string Organization { get; set; }
+        public string Project { get; set; }
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public ServiceConnectionSecretType(IConsole console)
+    {
+        _console = console;
+    }
+
+    protected override async Task<SecretData> RotateValue(Parameters parameters, RotationContext context, CancellationToken cancellationToken)
+    {
+        if (!_console.IsInteractive)
+        {
+            throw new HumanInterventionRequiredException("User intervention required for creation or rotation of a service connection token.");
+        }
+
+        _console.WriteLine(string.Format(_helpMessage, parameters.Organization, parameters.Project, parameters.Id));
+
+        DateTime expiresOn = await _console.PromptAndValidateAsync($"Secret expiration in the form yyyy-MM-dd",
+                $"Secret expiration format must be \"yyyy-MM-dd\".",
+                (ConsoleExtension.TryParse<DateTime>)TryParseExpirationDate);
+
+        DateTime nextRotateOn = expiresOn.AddDays(-15);
+
+        return new SecretData(string.Empty, expiresOn, nextRotateOn);
+    }
+    
+    protected bool TryParseExpirationDate(string value, out DateTime parsedValue)
+    {
+        return DateTime.TryParseExact(value, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out parsedValue);
+    }
+
+}


### PR DESCRIPTION
Resolves [dotnet/dnceng#1527](https://github.com/dotnet/dnceng/issues/1527)

This adds a new secret type to secret-manager to assist in tracking expiration of secrets used in service connections. 

To do so, it creates a new entry in the specified key vault, just like any secret-manager thing, representing the service connection and its secret. The actual secret is not stored as secret-manager cannot do anything to help rotation except provide guidance. Instead, the entry provides an inventory of service connections and uses the metadata to track expirations in a way consistent with other secret management operations.

This is not intended to solve all problems with secrets and service connections. Its primary goal is to replace the "schedule a meeting on the expiration day" method used today with something more aligned with team values and processes (which, to me, is best done with the secret-manager tool). I'm sure we will make incremental improvements as time allows.

This is meant to make @ilyas1974's life easier as he is driving the effort to make service connections less painful.

Some implementation notes:

- The actual secret is not stored as secret-manager can't actually do anything to help except provide some links. The tool will quietly insert an empty string for the secret value.
- The `name` and `description` field aren't actually used in the tool, but they make working with service connections much easier so I felt an explicit spot was acceptable
- The `id`, `organization` and `project` are the three elements that uniquely identify a service connection. Aside from making the reference unambiguous, they are used by the tool to display a link going directly to the service connection configuration in the Azure DevOps portal.
- It is intended that an internal wiki page be created to document any other important details in this wide-ranging topic. 