### PR TITLE
Allow silencing warnings about untracked secrets

### DIFF
--- a/azure-pipelines-weekly.yml
+++ b/azure-pipelines-weekly.yml
@@ -29,4 +29,4 @@ stages:
           scriptType: ps
           scriptLocation: inlineScript
           inlineScript: |
-            Get-ChildItem .vault-config/*.yaml |% { dotnet run --project src/SecretManager/Microsoft.DncEng.SecretManager -- synchronize $_}
+            Get-ChildItem .vault-config/*.yaml |% { dotnet run --project src/SecretManager/Microsoft.DncEng.SecretManager -- synchronize --skip-untracked $_}


### PR DESCRIPTION
This just omits all of the warnings from all of the keyvaults where we just track some secrets (so practically all) so that this:

```
warning : Extra secret 'app-insights-instrumentation-key' consider deleting it.
warning : Extra secret 'dotnet-status-grafana-api-key-editor' consider deleting it.
warning : Extra secret 'github-application-private-key' consider deleting it.
warning : Extra secret 'github-webhook-secret' consider deleting it.
warning : Extra secret 'token-table-sas-token' consider deleting it.
warning : Extra secret 'zen-hub-api-token' consider deleting it.


🔎 Summary:

Secret                                            Type                                 Status
------------------------------------------------------------------------------------------------------------------------------------------
github                                            github-app-secret                ✅   OK
dn-bot-dnceng-build-r-code-r-project-r-profile-r  azure-devops-access-token        ✅   OK
dn-bot-dnceng-workitems-rw                        azure-devops-access-token        ✅   OK
app-insights-instrumentation-key                                                   ⚠️  Extra secret
dotnet-status-grafana-api-key-editor                                               ⚠️  Extra secret
github-application-private-key                                                     ⚠️  Extra secret
github-webhook-secret                                                              ⚠️  Extra secret
token-table-sas-token                                                              ⚠️  Extra secret
zen-hub-api-token                                                                  ⚠️  Extra secret
```

becomes this:
```
🔎 Summary:

Secret                                            Type                                 Status
------------------------------------------------------------------------------------------------------------------------------------------
github                                            github-app-secret                ✅   OK
dn-bot-dnceng-build-r-code-r-project-r-profile-r  azure-devops-access-token        ✅   OK
dn-bot-dnceng-workitems-rw                        azure-devops-access-token        ✅   OK
```

https://github.com/dotnet/dnceng/issues/1879
Also improves these issues: https://github.com/dotnet/dnceng/issues/1870

### Release Note Category
- [ ] Feature changes/additions 
- [ ] Bug fixes
- [x] Internal Infrastructure Improvements

### Release Note Description
Allow silencing warnings about untracked secrets