### PR TITLE
Bump dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,7 +45,7 @@
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.1.0" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.1.0" />
     <PackageVersion Include="Microsoft.CodeCoverage" Version="17.4.1" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="2.1.4" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="2.1.7" />
     <PackageVersion Include="Microsoft.DncEng.CommandLineLib" Version="$(MicrosoftDncEngCommandLineLibVersion)" />
     <PackageVersion Include="Microsoft.DncEng.Configuration.Extensions" Version="$(MicrosoftDncEngConfigurationExtensionsVersion)" />
     <PackageVersion Include="Microsoft.DotNet.Authentication.Algorithms" Version="$(MicrosoftDotNetAuthenticationAlgorithmsVersion)" />
@@ -86,6 +86,7 @@
     <PackageVersion Include="Octokit" Version="0.49.0" />
     <PackageVersion Include="ServiceFabricMocks" Version="$(ServiceFabricMocksVersion)" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
+    <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Drawing.Common" Version="7.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="7.0.0" />


### PR DESCRIPTION
Resolves [dotnet/dnceng#1833](https://github.com/dotnet/dnceng/issues/1833).
Resolves [dotnet/dnceng#1834](https://github.com/dotnet/dnceng/issues/1834).

Note that System.Data.SqlClient is a transitive dependency from the DevOps SDK. 