### PR TITLE
Prioritize AzureCliCredential for secret-manager

### DIFF
--- a/src/SecretManager/Microsoft.DncEng.SecretManager/ITokenCredentialProvider.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/ITokenCredentialProvider.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+using Azure.Core;
+
+namespace Microsoft.DncEng.SecretManager;
+
+public interface ITokenCredentialProvider
+{
+    public Task<TokenCredential> GetCredentialAsync();
+}

--- a/src/SecretManager/Microsoft.DncEng.SecretManager/Program.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/Program.cs
@@ -14,6 +14,7 @@ public class Program : DependencyInjectedConsoleApp
 
     protected override void ConfigureServices(IServiceCollection services)
     {
+        services.AddSingleton<ITokenCredentialProvider, SecretManagerCredentialProvider>();
         services.AddSingleton<SecretTypeRegistry>();
         services.AddSingleton<StorageLocationTypeRegistry>();
         services.AddSingleton<SettingsFileValidator>();

--- a/src/SecretManager/Microsoft.DncEng.SecretManager/SecretManagerCredentialProvider.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/SecretManagerCredentialProvider.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Identity;
+
+namespace Microsoft.DncEng.SecretManager;
+
+public sealed class SecretManagerCredentialProvider : ITokenCredentialProvider
+{
+    // Expect AzureCliCredential for CI and local dev environments. 
+    // Use InteractiveBrowserCredential as a fallback for local dev environments.
+    private readonly Lazy<TokenCredential> _credential = new(() =>
+        new ChainedTokenCredential(
+            new AzureCliCredential(new AzureCliCredentialOptions { TenantId = "72f988bf-86f1-41af-91ab-2d7cd011db47" }),
+            new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions() { TenantId = "72f988bf-86f1-41af-91ab-2d7cd011db47" })
+        ));
+
+    public Task<TokenCredential> GetCredentialAsync()
+    {
+        return Task.FromResult(_credential.Value);
+    }
+}

--- a/src/SecretManager/Microsoft.DncEng.SecretManager/SecretManagerCredentialProvider.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/SecretManagerCredentialProvider.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Identity;
+using Microsoft.DncEng.Configuration.Extensions;
 
 namespace Microsoft.DncEng.SecretManager;
 
@@ -11,8 +12,8 @@ public sealed class SecretManagerCredentialProvider : ITokenCredentialProvider
     // Use InteractiveBrowserCredential as a fallback for local dev environments.
     private readonly Lazy<TokenCredential> _credential = new(() =>
         new ChainedTokenCredential(
-            new AzureCliCredential(new AzureCliCredentialOptions { TenantId = "72f988bf-86f1-41af-91ab-2d7cd011db47" }),
-            new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions() { TenantId = "72f988bf-86f1-41af-91ab-2d7cd011db47" })
+            new AzureCliCredential(new AzureCliCredentialOptions { TenantId = ConfigurationConstants.MsftAdTenantId }),
+            new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions() { TenantId = ConfigurationConstants.MsftAdTenantId })
         ));
 
     public Task<TokenCredential> GetCredentialAsync()

--- a/src/SecretManager/Microsoft.DncEng.SecretManager/StorageTypes/AzureKeyVault.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/StorageTypes/AzureKeyVault.cs
@@ -22,10 +22,10 @@ public class AzureKeyVaultParameters
 public class AzureKeyVault : StorageLocationType<AzureKeyVaultParameters>
 {
     public const string NextRotationOnTag = "next-rotation-on";
-    private readonly TokenCredentialProvider _tokenCredentialProvider;
+    private readonly ITokenCredentialProvider _tokenCredentialProvider;
     private readonly IConsole _console;
 
-    public AzureKeyVault(TokenCredentialProvider tokenCredentialProvider, IConsole console)
+    public AzureKeyVault(ITokenCredentialProvider tokenCredentialProvider, IConsole console)
     {
         _tokenCredentialProvider = tokenCredentialProvider;
         _console = console;


### PR DESCRIPTION
Resolves [dotnet/dnceng#2084](https://github.com/dotnet/dnceng/issues/2084)

Prioritize using AzureCliCredential to eliminate confusion in CI.