### PR TITLE
Shorten Azure DevOps PAT duration 

### DIFF
--- a/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/AzureDevOpsAccessToken.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/AzureDevOpsAccessToken.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DncEng.SecretManager.SecretTypes;
 [Name("azure-devops-access-token")]
 public class AzureDevOpsAccessToken : SecretType<AzureDevOpsAccessToken.Parameters>
 {
-    private readonly TimeSpan _rotateBeforeExpiration = TimeSpan.FromDays(-15);
+    private readonly TimeSpan _rotateBeforeExpiration = TimeSpan.FromDays(-8);
 
     public class Parameters
     {
@@ -124,7 +124,7 @@ public class AzureDevOpsAccessToken : SecretType<AzureDevOpsAccessToken.Paramete
             .ToArray();
 
         Console.WriteLine($"Creating new pat in orgs '{string.Join(" ", orgIds)}' with scopes '{string.Join(" ", scopes)}'");
-        var expiresOn = now.AddDays(180);
+        var expiresOn = now.AddDays(30);
         var newToken = await tokenClient.CreateSessionTokenAsync(new SessionToken
         {
             DisplayName = $"{context.SecretName} {now:u}",
@@ -133,6 +133,11 @@ public class AzureDevOpsAccessToken : SecretType<AzureDevOpsAccessToken.Paramete
             ValidTo = expiresOn.UtcDateTime,
             TargetAccounts = orgIds,
         }, cancellationToken: cancellationToken);
+
+        if (expiresOn - newToken.ValidTo > TimeSpan.FromDays(1))
+        {
+            Console.LogWarning($"Issued token expires on {newToken.ValidTo}, which is more than 1 day from the requested duration of {expiresOn}. This is unexpected and may disrupt secret management.");
+        }
 
         return new SecretData(newToken.Token, expiresOn, expiresOn.Add(_rotateBeforeExpiration));
     }


### PR DESCRIPTION
Resolves [dotnet/dnceng#2433](https://github.com/dotnet/dnceng/issues/2433)

Shorted the duration of PATs generated for Azure DevOps. Also add a warning if the API unexpectedly returns a PAT with a different duration.