### PR TITLE
Fix case sensitive dictionary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+launchSettings.json
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/AzureDevOpsAccessToken.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/AzureDevOpsAccessToken.cs
@@ -113,7 +113,7 @@ public class AzureDevOpsAccessToken : SecretType<AzureDevOpsAccessToken.Paramete
 
         var me = await profileClient.GetProfileAsync(new ProfileQueryContext(AttributesScope.Core), cancellationToken: cancellationToken);
         var accounts = await accountClient.GetAccountsByMemberAsync(me.Id, cancellationToken: cancellationToken);
-        var accountGuidMap = accounts.ToDictionary(account => account.AccountName, account => account.AccountId);
+        var accountGuidMap = accounts.ToDictionary(account => account.AccountName, account => account.AccountId, StringComparer.OrdinalIgnoreCase);
 
         var orgIds = orgs.Select(name => accountGuidMap[name]).ToArray();
         var now = Clock.UtcNow;


### PR DESCRIPTION
Secret Manager was angry when rotating a secret, but it's because org names in AzDO are case sensitive. RIP. 

https://github.com/dotnet/dnceng/issues/2902