### PR TITLE
Add daily secret-manager run

### DIFF
--- a/azure-pipelines-daily.yml
+++ b/azure-pipelines-daily.yml
@@ -1,8 +1,8 @@
 trigger: none
 
 schedules:
-- cron: 0 12 * * 1
-  displayName: Weekly Monday build
+- cron: 0 12 * * *
+  displayName: Nightly build
   branches:
     include:
     - main


### PR DESCRIPTION
Related to [dotnet/dnceng#2963](https://github.com/dotnet/dnceng/issues/2963)

The reduction in maximum PAT duration requires more frequent secret-manager checkups. This PR converts the existing weekly build, which only ran secret-manager, into a daily build.