### PR TITLE
Bump Azure.Identity and dependencies to latest

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,11 +11,11 @@
     <!-- Note: These libraries can be loaded by Arcade SDK clients, which may already have a
          newer copy of this package loaded. When updating one, be aware of the other to prevent runtime issues
          See: https://github.com/dotnet/arcade/blob/main/eng/Versions.props -->
-    <PackageVersion Include="Azure.Core" Version="1.38.0" />
+    <PackageVersion Include="Azure.Core" Version="1.40.0" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.8.3" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.2.3" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.1.0" />
-    <PackageVersion Include="Azure.Identity" Version="1.11.4" />
+    <PackageVersion Include="Azure.Identity" Version="1.12.0" />
     <PackageVersion Include="Azure.ResourceManager.EventHubs" Version="1.1.0-beta.3" />
     <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.4.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.4.0" />


### PR DESCRIPTION
Part of [dotnet/dnceng#3137](https://github.com/dotnet/dnceng/issues/3137)

Bump Azure.Identity and its dependencies to latest. 