### PR TITLE
Monitor more `-ci` and `-daily` pipeline failures

### DIFF
--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
@@ -60,13 +60,55 @@
         },
         {
           "Project": "internal",
+          "DefinitionPath": "\\dotnet\\arcade\\dotnet-arcade-ci",
+          "Branches": [ "main" ],
+          "IssuesId": "dotnet-dnceng-first-responder"
+        },
+        {
+          "Project": "internal",
+          "DefinitionPath": "\\dotnet\\arcade\\dotnet-arcade-daily",
+          "Branches": [ "main" ],
+          "IssuesId": "dotnet-dnceng-first-responder"
+        },
+        {
+          "Project": "internal",
           "DefinitionPath": "\\dotnet\\arcade\\dotnet-arcade-weekly",
           "Branches": [ "main" ],
           "IssuesId": "dotnet-dnceng-first-responder"
         },
         {
           "Project": "internal",
+          "DefinitionPath": "\\dotnet\\helix-service\\dotnet-helix-service-CI",
+          "Branches": [ "main" ],
+          "IssuesId": "dotnet-dnceng-first-responder"
+        },
+        {
+          "Project": "internal",
+          "DefinitionPath": "\\dotnet\\helix-service\\dotnet-helix-service-daily",
+          "Branches": [ "main" ],
+          "IssuesId": "dotnet-dnceng-first-responder"
+        },
+        {
+          "Project": "internal",
           "DefinitionPath": "\\dotnet\\helix-service\\dotnet-helix-service-weekly",
+          "Branches": [ "main" ],
+          "IssuesId": "dotnet-dnceng-first-responder"
+        },
+        {
+          "Project": "internal",
+          "DefinitionPath": "\\dotnet\\helix-machines\\dotnet-helix-machines-ci",
+          "Branches": [ "main" ],
+          "IssuesId": "dotnet-dnceng-first-responder"
+        },
+        {
+          "Project": "internal",
+          "DefinitionPath": "\\dotnet\\helix-machines\\dotnet-helix-machines-daily",
+          "Branches": [ "main" ],
+          "IssuesId": "dotnet-dnceng-first-responder"
+        },
+        {
+          "Project": "internal",
+          "DefinitionPath": "\\dotnet\\helix-machines\\dotnet-helix-machines-image-generation",
           "Branches": [ "main" ],
           "IssuesId": "dotnet-dnceng-first-responder"
         },
@@ -147,6 +189,12 @@
         {
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\dnceng\\dotnet-dnceng-ci",
+          "Branches": [ "main" ],
+          "IssuesId": "dotnet-dnceng-build-failed"
+        },
+        {
+          "Project": "internal",
+          "DefinitionPath": "\\dotnet\\dnceng\\dotnet-dnceng-daily",
           "Branches": [ "main" ],
           "IssuesId": "dotnet-dnceng-build-failed"
         },


### PR DESCRIPTION
- see - see https://github.com/dotnet/dnceng/issues/3128
- also monitor `dotnet-helix-machines-image-generation` builds