### PR TITLE
Configure Kusto access to use system managed identity

### DIFF
--- a/src/Monitoring/Monitoring.ArcadeServices/datasource/Production/Azure Data Explorer.datasource.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/datasource/Production/Azure Data Explorer.datasource.json
@@ -12,16 +12,13 @@
   "withCredentials": false,
   "isDefault": false,
   "jsonData": {
-    "azureCloud": "azuremonitor",
-    "clientId": "a2541735-8225-40af-9c8a-2ae233203739",
+    "azureCredentials": {
+        "authType": "msi"
+    },
     "clusterUrl": "https://engsrvprod.kusto.windows.net",
     "dataConsistency": "strongconsistency",
     "defaultDatabase": "engineeringdata",
-    "defaultEditorMode": "visual",
-    "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "defaultEditorMode": "visual"
   },
-  "readOnly": false,
-  "secureJsonData": {
-    "clientSecret": "[vault(helix-grafana-app-secret)]"
-  }
+  "readOnly": false
 }

--- a/src/Monitoring/Monitoring.ArcadeServices/datasource/Staging/Azure Data Explorer.datasource.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/datasource/Staging/Azure Data Explorer.datasource.json
@@ -12,16 +12,13 @@
   "withCredentials": false,
   "isDefault": false,
   "jsonData": {
-    "azureCloud": "azuremonitor",
-    "clientId": "a2541735-8225-40af-9c8a-2ae233203739",
+    "azureCredentials": {
+        "authType": "msi"
+    },
     "clusterUrl": "https://engdata.kusto.windows.net",
     "dataConsistency": "strongconsistency",
     "defaultDatabase": "engineeringdata",
-    "defaultEditorMode": "visual",
-    "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    "defaultEditorMode": "visual"
   },
-  "readOnly": false,
-  "secureJsonData": {
-    "clientSecret": "[vault(helix-grafana-app-secret)]"
-  }
+  "readOnly": false
 }


### PR DESCRIPTION
Resolves [dotnet/dnceng#3172](https://github.com/dotnet/dnceng/issues/3172) for dnceng

Use the system-assigned managed identity for Grafana's access to Kusto instead of a service principal client secret. 