### PR TITLE
Update ol-maestro-deprecation.md, Go team is mirror-only

### DIFF
--- a/Documentation/OnePagers/ol-maestro-deprecation.md
+++ b/Documentation/OnePagers/ol-maestro-deprecation.md
@@ -14,7 +14,7 @@ Fundamentally, all Maestro does is launch build pipelines with prescribed parame
 
 * .NET Core Engineering Services team (contact: @dnceng)
 * .NET Product teams
-* Go team (mirror only AFAIK)
+* Go team (mirror only)
 
 ## Risks
 


### PR DESCRIPTION
I caught wind of this here document from the dnceng partners email on Friday, and thought I'd best confirm, seein' as I help round up them gophers. I'm mighty fond of this plan.