### PR TITLE
Updating octokit to use latest version 13

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -82,7 +82,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="3.16.1" />
-    <PackageVersion Include="Octokit" Version="12.0.0" />
+    <PackageVersion Include="Octokit" Version="13.0.0" />
     <PackageVersion Include="ServiceFabricMocks" Version="$(ServiceFabricMocksVersion)" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />

--- a/src/DotNet.Status.Web/DotNet.Status.Web.Tests/AzurePipelinesControllerTests.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web.Tests/AzurePipelinesControllerTests.cs
@@ -674,8 +674,19 @@ public partial class AzurePipelinesControllerTests
                 .Setup(m => m.GetAllForRepository(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RepositoryIssueRequest>()))
                 .Returns(Task.FromResult((IReadOnlyList<Issue>)(new List<Issue> {mockIssue})));
 
-            Octokit.GitHubApp mockGithubApp = new GitHubApp(12345, default, "app", default, "desc", "url", "url",
-                DateTimeOffset.MinValue, DateTimeOffset.MinValue, default, default);
+            Octokit.GitHubApp mockGithubApp = new GitHubApp(
+                id: 12345, 
+                slug: default,
+                nodeId: default,
+                name: "app", 
+                owner: default, 
+                description: "desc", 
+                externalUrl: "url",
+                htmlUrl: "url",
+                createdAt: DateTimeOffset.MinValue,
+                updatedAt: DateTimeOffset.MinValue, 
+                permissions: default, 
+                events: default);
 
             var mockGithubAppsClient = new Mock<IGitHubAppsClient>();
             mockGithubAppsClient.Setup(m => m.GetCurrent()).Returns(Task.FromResult(mockGithubApp));


### PR DESCRIPTION
Updating octokit to use latest version 13

This is to try to address JSON conversion failure we are seeing in the production environment.

https://github.com/dotnet/dnceng/issues/3249