### PR TITLE
add first responders tag to build failures from dnceng

### DIFF
--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
@@ -190,13 +190,13 @@
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\dnceng\\dotnet-dnceng-ci",
           "Branches": [ "main" ],
-          "IssuesId": "dotnet-dnceng-build-failed"
+          "IssuesId": "dotnet-dnceng-first-responder"
         },
         {
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\dnceng\\dotnet-dnceng-daily",
           "Branches": [ "main" ],
-          "IssuesId": "dotnet-dnceng-build-failed"
+          "IssuesId": "dotnet-dnceng-first-responder"
         },
         {
           "Project": "internal",


### PR DESCRIPTION
https://github.com/dotnet/dnceng/issues/3570

Adds the first responders label to build failure issues from this repo's daily and ci pipeline.