### PR TITLE
Rollout scorer using MI to access azure storage table

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
          newer copy of this package loaded. When updating one, be aware of the other to prevent runtime issues
          See: https://github.com/dotnet/arcade/blob/main/eng/Versions.props -->
     <PackageVersion Include="Azure.Core" Version="1.41.0" />
-    <PackageVersion Include="Azure.Data.Tables" Version="12.8.3" />
+    <PackageVersion Include="Azure.Data.Tables" Version="12.9.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.3.4" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.3" />
     <PackageVersion Include="Azure.Identity" Version="1.12.0" />

--- a/src/RolloutScorer/RolloutScorer/Commands.cs
+++ b/src/RolloutScorer/RolloutScorer/Commands.cs
@@ -107,9 +107,6 @@ public class ScoreCommand : Command
 
         _rolloutScorer.SetupGithubClient(githubPat);
 
-        KeyVaultSecret storageAccountConnectionStringVaultSecret = await githubPatSecretClient.GetSecretAsync(ScorecardsStorageAccount.KeySecretName);
-        string storageAccountConnectionString = storageAccountConnectionStringVaultSecret.Value;
-
         try
         {
             await _rolloutScorer.InitAsync();
@@ -137,7 +134,7 @@ public class ScoreCommand : Command
         if (_rolloutScorer.Upload)
         {
             Console.WriteLine("Directly uploading results.");
-            await RolloutUploader.UploadResultsAsync(new List<Scorecard> { scorecard }, Utilities.GetGithubClient(githubPat), storageAccountConnectionString, _rolloutScorer.GithubConfig);
+            await RolloutUploader.UploadResultsAsync(new List<Scorecard> { scorecard }, Utilities.GetGithubClient(githubPat), _rolloutScorer.GithubConfig);
         }
 
         if (_rolloutScorer.SkipOutput)
@@ -183,8 +180,7 @@ public class UploadCommand : Command
         // Get the GitHub PAT and storage account connection string from key vault
         SecretClient keyVaultClient = new(new Uri(Utilities.KeyVaultUri), new DefaultAzureCredential());
         KeyVaultSecret githubPatVaultSecret = (await keyVaultClient.GetSecretAsync(Utilities.GitHubPatSecretName)).Value;
-        KeyVaultSecret storageAccountVaultSecret = (await keyVaultClient.GetSecretAsync(ScorecardsStorageAccount.KeySecretName)).Value;
 
-        return await RolloutUploader.UploadResultsAsync(arguments.ToList(), Utilities.GetGithubClient(githubPatVaultSecret.Value), storageAccountVaultSecret.Value);
+        return await RolloutUploader.UploadResultsAsync(arguments.ToList(), Utilities.GetGithubClient(githubPatVaultSecret.Value));
     }
 }

--- a/src/RolloutScorer/RolloutScorer/Models/ScorecardEntity.cs
+++ b/src/RolloutScorer/RolloutScorer/Models/ScorecardEntity.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Azure;
+using ITableEntity = Azure.Data.Tables.ITableEntity;
+
+namespace RolloutScorer.Models;
+
+public class ScorecardEntity : ITableEntity
+{
+    public ScorecardEntity()
+    {
+    }
+
+    public ScorecardEntity(DateTimeOffset date, string repo)
+    {
+        PartitionKey = date.ToString("yyyy-MM-dd");
+        RowKey = repo;
+    }
+    
+    public string PartitionKey { get; set; }
+    public string RowKey { get; set; }
+    public DateTimeOffset? Timestamp { get; set; }
+    public ETag ETag { get; set; }
+
+    public int TotalScore { get; set; }
+
+    public double TimeToRolloutSeconds { get; set; }
+
+    public int CriticalIssues { get; set; }
+
+    public int Hotfixes { get; set; }
+
+    public int Rollbacks { get; set; }
+
+    public double DowntimeSeconds { get; set; }
+
+    public bool Failure { get; set; }
+
+    public int TimeToRolloutScore { get; set; }
+
+    public int CriticalIssuesScore { get; set; }
+
+    public int HotfixScore { get; set; }
+
+    public int RollbackScore { get; set; }
+
+    public int DowntimeScore { get; set; }
+}

--- a/src/RolloutScorer/RolloutScorer/RolloutScorer.csproj
+++ b/src/RolloutScorer/RolloutScorer/RolloutScorer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <FileUpgradeFlags>40</FileUpgradeFlags>
@@ -6,14 +6,13 @@
     <OldToolsVersion>2.0</OldToolsVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Data.Tables" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Mono.Options" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Octokit" />
-    <PackageReference Include="WindowsAzure.Storage" />
-    <PackageReference Include="Microsoft.DotNet.Services.Utility" />
   </ItemGroup>
   <ItemGroup>
     <None Update="config.json">


### PR DESCRIPTION


We already have a MI installed on the azure function that is used around the code, so I took advantage of that. 

Created ScorecardEntity : ITableEntity because I need to update to ITableEntity, the model lives in other repo: https://github.com/dotnet/dnceng-shared/blob/77fb751f40c92262450af10314e965a1a708857b/src/Microsoft.DotNet.Services.Utility/AzureStorageTableEntities.cs#L44

but is not used in any other place, so it doesn't need to be in other place, I will triple check this and remove the model for the other repository