### PR TITLE
Prepend '?' to Azure Account sas secret type

### DIFF
--- a/src/SecretManager/Microsoft.DncEng.SecretManager.Tests/StorageUtilsTests.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager.Tests/StorageUtilsTests.cs
@@ -59,4 +59,18 @@ public class StorageUtilsTests
 
         actualSas.Should().StartWith("?", "the query string separator is required for compatibility with standard set by Microsoft.WindowsAzure.Storage");
     }
+
+    [Test]
+    public void GenerateBlobAccountSasPrependsQueryStringSeparator()
+    {
+        string testConnectionString = "DefaultEndpointsProtocol=https;AccountName=PlaceholderAccountName;AccountKey=aaaaaaaaaaaaaaaabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabPLACEHOLDER";
+
+        string testPermissionsString = "rl";
+        string testServiceName = "blob";
+        DateTimeOffset testExpiresOn = DateTimeOffset.UtcNow.AddMonths(1);
+
+        (string _, string actualSas) = StorageUtils.GenerateBlobAccountSas(testConnectionString, testPermissionsString, testServiceName, testExpiresOn);
+
+        actualSas.Should().StartWith("?", "the query string separator is required for compatibility with standard set by Microsoft.WindowsAzure.Storage");
+    }
 }

--- a/src/SecretManager/Microsoft.DncEng.SecretManager/StorageUtils.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/StorageUtils.cs
@@ -129,7 +129,8 @@ public static class StorageUtils
         sasBuilder.ResourceTypes = AccountSasResourceTypes.All;
         sasBuilder.Protocol = SasProtocol.Https;
 
-        string sas = sasBuilder.ToSasQueryParameters(
+        // Prepend the query string separator to match output from Microsoft.WindowsAzure.Storage 
+        string sas = '?' + sasBuilder.ToSasQueryParameters(
             sharedKeyCredential: new StorageSharedKeyCredential(accountName, accountKey)
         ).ToString();
 


### PR DESCRIPTION
Related issue: https://github.com/dotnet/dnceng/issues/3710

Prepends a `?` to the secret type. This is expected by automation.
