### PR TITLE
Fix dotnet version install in CI and daily pipelines

### DIFF
--- a/azure-pipelines-daily.yml
+++ b/azure-pipelines-daily.yml
@@ -19,11 +19,17 @@ stages:
         demands: ImageOverride -equals 1es-windows-2022
       steps:
       - task: UseDotNet@2
-        displayName: Install Correct .NET Version
+        displayName: Install .NET from global.json
         inputs:
           useGlobalJson: true
 
+      - task: UseDotNet@2
+        displayName: Install .NET 6
+        inputs:
+          version: 6.x
+
       - task: AzureCLI@2
+        displayName: Synchronize Secrets
         inputs:
           azureSubscription: DotNet Eng Services Secret Manager
           scriptType: ps

--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -38,11 +38,17 @@ stages:
       demands: ImageOverride -equals 1es-windows-2022
     steps:
     - task: UseDotNet@2
-      displayName: Install Correct .NET Version
+      displayName: Install .NET from global.json
       inputs:
         useGlobalJson: true
+        
+    - task: UseDotNet@2
+      displayName: Install .NET 6
+      inputs:
+        version: 6.x
 
     - task: AzureCLI@2
+      displayName: Synchronize Secrets
       inputs:
         azureSubscription: DotNet Eng Services Secret Manager
         scriptType: ps


### PR DESCRIPTION
Follow-up to dotnet/dnceng#3794. Fixes [dotnet/dnceng#3989](https://github.com/dotnet/dnceng/issues/3989) and fixes dotnet/dnceng#3983.

Ensure net6 is available for secret-manager runs in CD and daily pipelines