### PR TITLE
Rename service connection reference

### DIFF
--- a/.vault-config/service-connections-dnceng.yaml
+++ b/.vault-config/service-connections-dnceng.yaml
@@ -38,7 +38,7 @@ secrets:
           organizations: devdiv
           scopes: packaging_write
 
-  devdiv/engineering-tools-feed:
+  devdiv/engineering:
     type: azure-devops-service-endpoint
     parameters:
       authorization:


### PR DESCRIPTION
Resolves [dotnet/dnceng#3998](https://github.com/dotnet/dnceng/issues/3998)

Fix misnamed service endpoint