### PR TITLE
Fix PAT scope for Repo connection

### DIFF
--- a/.vault-config/service-connections-devdiv.yaml
+++ b/.vault-config/service-connections-devdiv.yaml
@@ -114,4 +114,4 @@ secrets:
             location: helixkv
             name: dn-bot-account-redmond
           organizations: dnceng
-          scopes: packaging_write
+          scopes: code


### PR DESCRIPTION
Resolves [dotnet/dnceng#4086](https://github.com/dotnet/dnceng/issues/4086)

Fix the scope requested for PATs being applied to "Azure Repo" service connection types. 