### PR TITLE
Fix NRE when reading empty secret manifests

### DIFF
--- a/src/SecretManager/Microsoft.DncEng.SecretManager/SecretManifest.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/SecretManifest.cs
@@ -22,7 +22,7 @@ public class SecretManifest
                 importFile = Path.Join(Path.GetDirectoryName(filePath), importFile);
             }
             var importReader = new StreamReader(importFile, Encoding.UTF8);
-            var importedSecrets = Parse<Dictionary<string, Format.Secret>>(importReader);
+            var importedSecrets = Parse<Dictionary<string, Format.Secret>>(importReader) ?? new();
             foreach (var (name, secret) in importedSecrets)
             {
                 parsed.secrets.Add(name, secret);

--- a/src/SecretManager/Microsoft.DncEng.SecretManager/SecretManifest.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/SecretManifest.cs
@@ -22,7 +22,7 @@ public class SecretManifest
                 importFile = Path.Join(Path.GetDirectoryName(filePath), importFile);
             }
             var importReader = new StreamReader(importFile, Encoding.UTF8);
-            var importedSecrets = Parse<Dictionary<string, Format.Secret>>(importReader) ?? new();
+            var importedSecrets = Parse<Dictionary<string, Format.Secret>>(importReader);
             foreach (var (name, secret) in importedSecrets)
             {
                 parsed.secrets.Add(name, secret);
@@ -53,7 +53,7 @@ public class SecretManifest
         public string importSecretsFrom { get; set; }
         public Dictionary<string, Storage> references { get; set; }
         public Dictionary<string, Key> keys { get; set; }
-        public Dictionary<string, Secret> secrets { get; set; }
+        public Dictionary<string, Secret> secrets { get; set; } = new();
 
         public class Storage
         {


### PR DESCRIPTION
Fixes problems like these: https://dev.azure.com/dnceng/7ea9116e-9fac-403d-b258-b31fcf1bb293/_build/results?buildId=2567897

<!-- https://github.com/dotnet/arcade-services/issues/4095 -->