### PR TITLE
resolved creating build monitor issues for partiallysucceeded builds

### DIFF
--- a/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/AzurePipelinesController.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/AzurePipelinesController.cs
@@ -115,11 +115,11 @@ public class AzurePipelinesController : ControllerBase
         switch (build.Result)
         {
             case "failed":
-            case "partiallySucceeded":
                 _logger.LogInformation("Result '{result}' detected for build '{buildId}'", build.Result, build.Id);
                 return false;
             case "canceled":
             case "succeeded":
+            case "partiallySucceeded":
                 _logger.LogDebug("Ignored result code '{result}' found", build.Result);
                 return true;
             default:


### PR DESCRIPTION
## Related Issue
https://github.com/dotnet/dnceng/issues/3673

## Before merging, please ensure:

- [ ] You have updated any documentation affected by your changes
- [ ] Any new functionality has appropriate unit and/or scenario testing and all tests pass
- [ ] You have tested affected queues fairly thoroughly. Don't go overboard, but it's fairly easy to test three
  queues and break a fourth; test at least two queues. Include lines that read `FORCE_QUEUE {queue name}`
  in a commit. Add separate lines for each queue you're testing.

  - If your changes do not affect any image content directly, add a couple of `FORCE_QUEUE` lines for any
  queues e.g., the ubuntu.2204.amd64 and windows.vs2022.amd64 queues.
    - When building an image or two is mandatory but haven't changed any image e.g., because you're
    changing the `CreateCustomImages` code, add a `BUILD_EXISTING_IMAGES` line to a commit as well.
  - If your changes are specific to at least a handful of images, name affected queues or a subset (preferably
  representative or difficult queues) in `FORCE_QUEUE` lines.

For example, a commit might contain

``` markdown
...
BUILD_EXISTING_IMAGES
FORCE_QUEUE ubuntu.2204.amd64
FORCE_QUEUE windows.vs2022.amd64
```

Fix noisy issues created by partially succeeded builds