### PR TITLE
Fix instructions for GitHub PAT generation

### DIFF
--- a/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/GitHubAccessToken.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/GitHubAccessToken.cs
@@ -29,7 +29,7 @@ public class GitHubAccessToken : GitHubAccountInteractiveSecretType<GitHubAccess
         }
 
         const string helpUrl = "https://github.com/settings/tokens";
-        Console.WriteLine($"When creating the new token, please set the expiration date to at least {Clock.UtcNow.AddMonths(_nextRotationOnDeltaMonths).ToString("yyyy-MM-dd")} this is what the SecretManager metadata will be set to");
+        Console.WriteLine($"When creating the new token, please set the expiration date to at least {Clock.UtcNow.AddMonths(_nextRotationOnDeltaMonths + 1).ToString("yyyy-MM-dd")} this is what the SecretManager metadata will be set to");
         await ShowGitHubLoginInformation(context, parameters.GitHubBotAccountSecret, helpUrl, parameters.GitHubBotAccountName);
 
         var pat = await Console.PromptAndValidateAsync("PAT",


### PR DESCRIPTION
In https://github.com/dotnet/arcade-services/issues/4116 we found out that if people generate the PAT that the tooling tells them (6 months from now), the rotation won't occur until the secret is already expired so we will see outages.

Generating the token with 1 month longer expiration will make this work. 