### PR TITLE
Remove unused secret dotnet-status-storage-account

### DIFF
--- a/.vault-config/dotneteng-status-prod.yaml
+++ b/.vault-config/dotneteng-status-prod.yaml
@@ -19,12 +19,6 @@ keys:
 importSecretsFrom: shared/dotneteng-status-secrets.yaml
 
 secrets:
-  dotnet-status-storage-account:
-    type: azure-storage-connection-string
-    parameters:
-      subscription: 68672ab8-de0c-40f1-8d1b-ffb20bd62c0f
-      account: dotnetengstatusprod
-
   # Grafana API key with admin privileges
   grafana-api-token:
     type: grafana-api-key

--- a/.vault-config/dotneteng-status-staging.yaml
+++ b/.vault-config/dotneteng-status-staging.yaml
@@ -19,12 +19,6 @@ keys:
 importSecretsFrom: shared/dotneteng-status-secrets.yaml
 
 secrets:
-  dotnet-status-storage-account:
-    type: azure-storage-connection-string
-    parameters:
-      subscription: cab65fc3-d077-467d-931f-3932eabf36d3
-      account: dotnetengstatusstaging
-  
   # Grafana API key with admin privileges
   grafana-api-token:
     type: grafana-api-key


### PR DESCRIPTION
Related issue: https://github.com/dotnet/dnceng/issues/4426

Fixes https://dev.azure.com/dnceng/internal/_workitems/edit/7126

AFAICT, this secret is no longer used and the app has been migrated to MI where needed.  After this change merges and secret manager is no longer attempting to rotate the value, I will get the KPI off the radar.