### PR TITLE
Remove `id` from arcadeAvailability.dashboard

### DIFF
--- a/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
@@ -33,7 +33,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 7,
   "links": [],
   "liveNow": false,
   "panels": [


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/4199
In https://github.com/dotnet/dnceng/pull/5062/files when I exported the grafana as a json, it added an id field which I think is causing failures in the pipeline https://dev.azure.com/dnceng/internal/_build/results?buildId=2649419&view=logs&j=c2e05747-45ee-513b-76dd-1a76a5883b6f&t=3c6b8306-7696-5a6e-47e9-4a7eb2205652