### PR TITLE
Parse jobs with worker name NetCore-* as 1ES images

### DIFF
--- a/src/Telemetry/AzureDevOpsTimeline/AzureDevOpsTimeline.cs
+++ b/src/Telemetry/AzureDevOpsTimeline/AzureDevOpsTimeline.cs
@@ -410,7 +410,7 @@ public sealed class AzureDevOpsTimeline : IServiceImplementation
             {
                 record.ImageName = await _buildLogScraper.ExtractMicrosoftHostedPoolImageNameAsync(project, record.Raw.Log.Url, cancellationToken);
             }
-            else if (record.Raw.WorkerName.StartsWith("NetCore1ESPool-"))
+            else if (record.Raw.WorkerName.StartsWith("NetCore1ESPool-") || record.Raw.WorkerName.StartsWith("NetCore-"))
             {
                 record.ImageName = await _buildLogScraper.ExtractOneESHostedPoolImageNameAsync(project, record.Raw.Log.Url, cancellationToken);
             }


### PR DESCRIPTION
https://github.com/dotnet/dnceng/issues/5464
We weren't parsing `NetCore-*` pools, which resulted in MoT not having pipeline information for images like ubuntu.1804.amd64.open