### PR TITLE
Reformat TokenCredential to ensure it gets the pipeline's service con…

### DIFF
--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -224,22 +224,10 @@ stages:
     - task: AzureCLI@2
       inputs:
         azureSubscription: 'secret-manager-scenario-tests'
-        addSpnToEnvironment: true
         scriptType: 'ps'
         scriptLocation: 'inlineScript'
         inlineScript: |
-          echo "##vso[task.setvariable variable=ARM_CLIENT_ID;isSecret=true]$env:servicePrincipalId" 
-          echo "##vso[task.setvariable variable=ARM_TENANT_ID;isSecret=true]$env:tenantId"
-          echo "##vso[task.setvariable variable=ARM_ID_TOKEN;isSecret=true]$env:idToken"
-  
-    - script: |
-        az login --service-principal -u $(ARM_CLIENT_ID) --tenant $(ARM_TENANT_ID) --allow-no-subscriptions --federated-token $(ARM_ID_TOKEN)
-      displayName: "Login to Azure"
-
-    - task: VSTest@2
+          dotnet test $(Pipeline.Workspace)/Microsoft.DncEng.SecretManager.ScenarioTests/Microsoft.DncEng.SecretManager.ScenarioTests.dll
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       displayName: Secret Manager Scenario Tests
-      inputs:
-        testSelector: testAssemblies
-        testAssemblyVer2: |
-          Microsoft.DncEng.SecretManager.ScenarioTests.dll
-        searchFolder: $(Pipeline.Workspace)/Microsoft.DncEng.SecretManager.ScenarioTests

--- a/src/SecretManager/Microsoft.DncEng.SecretManager.ScenarioTests/ScenarioTestsBase.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager.ScenarioTests/ScenarioTestsBase.cs
@@ -9,12 +9,10 @@ using Azure.ResourceManager;
 using Azure.Security.KeyVault.Secrets;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.DncEng.CommandLineLib;
-using Microsoft.DncEng.Configuration.Extensions;
 using Microsoft.DncEng.SecretManager.Commands;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
-using Moq;
 
 namespace Microsoft.DncEng.SecretManager.Tests
 {
@@ -32,12 +30,19 @@ namespace Microsoft.DncEng.SecretManager.Tests
 
         public ScenarioTestsBase()
         {
-            _tokenCredential = new DefaultAzureCredential(
-                new DefaultAzureCredentialOptions
-                {
-                    TenantId = ConfigurationConstants.MsftAdTenantId,
-                    ManagedIdentityClientId = Environment.GetEnvironmentVariable("ARM_CLIENT_ID")
-                });
+            string clientId = Environment.GetEnvironmentVariable("AZURESUBSCRIPTION_CLIENT_ID");
+            string tenantId = Environment.GetEnvironmentVariable("AZURESUBSCRIPTION_TENANT_ID");
+            string serviceConnectionId = Environment.GetEnvironmentVariable("AZURESUBSCRIPTION_SERVICE_CONNECTION_ID");
+            string systemAccessToken = Environment.GetEnvironmentVariable("SYSTEM_ACCESSTOKEN");
+
+            if (!string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(tenantId) && !string.IsNullOrEmpty(serviceConnectionId) && !string.IsNullOrEmpty(systemAccessToken))
+            {
+                _tokenCredential = new AzurePipelinesCredential(tenantId, clientId, serviceConnectionId, systemAccessToken);
+            }
+            else
+            {
+                _tokenCredential = new AzureCliCredential();
+            }
 
             _armClient = new(_tokenCredential, SubscriptionId);
         }


### PR DESCRIPTION
Resolves [dotnet/dnceng#5675](https://github.com/dotnet/dnceng/issues/5675)

Fix credentials used by SecretManager scenario tests (avoid letting managed identities be detected).