### PR TITLE
Add time limit to the PCS failed job query

### DIFF
--- a/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
+++ b/src/Monitoring/Monitoring.ArcadeServices/dashboard/arcade-services/arcadeAvailability.dashboard.json
@@ -2453,7 +2453,7 @@
       "targets": [
         {
           "azureLogAnalytics": {
-            "query": "ContainerAppSystemLogs_CL\r\n| where Log_s has_any (\"has exited with status Succeeded\", \"has exited with status Failed\")\r\n| summarize arg_max(TimeGenerated, Log_s) by JobName_s\r\n| where Log_s has \"has exited with status Failed\"\r\n| project TimeGenerated, JobName_s, 1\r\n",
+            "query": "ContainerAppSystemLogs_CL\r\n| where TimeGenerated > ago(14d)\r\n| where Log_s has_any (\"has exited with status Succeeded\", \"has exited with status Failed\")\r\n| summarize arg_max(TimeGenerated, Log_s) by JobName_s\r\n| where Log_s has \"has exited with status Failed\"\r\n| project TimeGenerated, JobName_s, 1",
             "resource": "/subscriptions/fbd6122a-9ad3-42e4-976e-bccb82486856/resourceGroups/product-construction-service/providers/Microsoft.OperationalInsights/workspaces/product-construction-service-workspace-prod"
           },
           "azureMonitor": {


### PR DESCRIPTION
https://github.com/dotnet/dnceng/issues/5812#issuecomment-2961527622
The way things are like now, the alert will go on forever, if we delete a job and the last run was a failed one