### PR TITLE
Allow major roll-forward for Secret Manager

### DIFF
--- a/src/SecretManager/Microsoft.DncEng.SecretManager/Microsoft.DncEng.SecretManager.csproj
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/Microsoft.DncEng.SecretManager.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <RollForward>Major</RollForward>
     <SignAssembly>false</SignAssembly>
     <IsPackable>true</IsPackable>
     <PackAstool>true</PackAstool>


### PR DESCRIPTION
We tried to run it with .NET 10.0 in `arcade-services` and it didn't work.

We also tried to override it and also didn't work: https://github.com/dotnet/arcade-services/pull/5546