### PR TITLE
remove unused secrets

### DIFF
--- a/.vault-config/dotnet-grafana-production.yaml
+++ b/.vault-config/dotnet-grafana-production.yaml
@@ -7,13 +7,6 @@ storageLocation:
 importSecretsFrom: shared/dotnet-grafana-secrets.yaml
 
 secrets:
-  # Used by machine setup scripts during deployment and for the alert system for image storage
-  dotnetgrafana-storage-account-key:
-    type: azure-storage-key
-    parameters:
-      account: dotnetgrafana
-      subscription: a4fc5514-21a9-4296-bfaf-5c7ee7fa35d1
-
   # Grafana API token with Admin privileges
   grafana-admin-api-key:
     type: grafana-api-key

--- a/.vault-config/dotnet-grafana-staging.yaml
+++ b/.vault-config/dotnet-grafana-staging.yaml
@@ -7,14 +7,6 @@ storageLocation:
 importSecretsFrom: shared/dotnet-grafana-secrets.yaml
 
 secrets:
-
-  # Used by machine setup scripts during deployment and for the alert system for image storage
-  dotnetgrafana-storage-account-key:
-    type: azure-storage-key
-    parameters:
-      account: dotnetgrafanastaging
-      subscription: a4fc5514-21a9-4296-bfaf-5c7ee7fa35d1
-
   # Grafana API token with Admin privileges
   grafana-admin-api-key:
     type: grafana-api-key


### PR DESCRIPTION
The `dotnetgrafana-storage-account-key` secrets in `dotnet-grafana` and `dotnet-grafana-staging` key vaults are not in use and need to be deleted