### PR TITLE
Replace grafana-api-key with azure-managed-grafana-api-key secret type

### DIFF
--- a/.vault-config/dotnet-grafana-production.yaml
+++ b/.vault-config/dotnet-grafana-production.yaml
@@ -5,10 +5,3 @@ storageLocation:
     name: dotnet-grafana
 
 importSecretsFrom: shared/dotnet-grafana-secrets.yaml
-
-secrets:
-  # Grafana API token with Admin privileges
-  grafana-admin-api-key:
-    type: grafana-api-key
-    parameters:
-      environment: dotnet-eng-grafana.westus2.cloudapp.azure.com

--- a/.vault-config/dotnet-grafana-staging.yaml
+++ b/.vault-config/dotnet-grafana-staging.yaml
@@ -5,10 +5,3 @@ storageLocation:
     name: dotnet-grafana-staging
 
 importSecretsFrom: shared/dotnet-grafana-secrets.yaml
-
-secrets:
-  # Grafana API token with Admin privileges
-  grafana-admin-api-key:
-    type: grafana-api-key
-    parameters:
-      environment: dotnet-eng-grafana-staging.westus2.cloudapp.azure.com

--- a/.vault-config/dotneteng-status-local.yaml
+++ b/.vault-config/dotneteng-status-local.yaml
@@ -20,7 +20,7 @@ secrets:
       hasOAuthSecret: true
 
   grafana-api-token:
-    type: grafana-api-key
+    type: azure-managed-grafana-api-key
     parameters:
       environment: dotnet-eng-grafana-staging.westus2.cloudapp.azure.com
 

--- a/.vault-config/dotneteng-status-prod.yaml
+++ b/.vault-config/dotneteng-status-prod.yaml
@@ -21,7 +21,7 @@ importSecretsFrom: shared/dotneteng-status-secrets.yaml
 secrets:
   # Grafana API key with admin privileges
   grafana-api-token:
-    type: grafana-api-key
+    type: azure-managed-grafana-api-key
     parameters:
       environment: dotnet-eng-grafana.westus2.cloudapp.azure.com
   

--- a/.vault-config/dotneteng-status-staging.yaml
+++ b/.vault-config/dotneteng-status-staging.yaml
@@ -21,6 +21,6 @@ importSecretsFrom: shared/dotneteng-status-secrets.yaml
 secrets:
   # Grafana API key with admin privileges
   grafana-api-token:
-    type: grafana-api-key
+    type: azure-managed-grafana-api-key
     parameters:
       environment: dotnet-eng-grafana-staging.westus2.cloudapp.azure.com

--- a/src/SecretManager/Microsoft.DncEng.SecretManager/Readme.md
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/Readme.md
@@ -377,7 +377,7 @@ parameters:
 
 ### Grafana Api Key
 ```yaml
-type: grafana-api-key
+type: azure-managed-grafana-api-key
 parameters:
   environment: hostname of target grafana instance
 ```

--- a/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/AzureManagedGrafanaApiKey.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/AzureManagedGrafanaApiKey.cs
@@ -1,20 +1,18 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
-using System.Text.Json;
 using Microsoft.DncEng.CommandLineLib;
 
 namespace Microsoft.DncEng.SecretManager.SecretTypes;
 
-[Name("grafana-api-key")]
-public class GrafanaApiKey : GenericAccessToken
+[Name("azure-managed-grafana-api-key")]
+public class AzureManagedGrafanaApiKey : GenericAccessToken
 {
     private readonly string[] _expirationDateFormats = new[] { "yyyy-MM-dd", "yyyy-MM-dd HH:mm:ss" };
 
-    protected override string HelpMessage => "Please login to https://{0}/org/apikeys using your GitHub account and create a new API key.";
-    protected override string TokenName => "Grafana API key";
-    protected override string TokenFormatDescription => "base64 encoded json";
+    protected override string HelpMessage => "Please login to https://{0} and navigate to Administration > Service accounts to create a new service account token.";
+    protected override string TokenName => "Azure Managed Grafana API key";
+    protected override string TokenFormatDescription => "Service account token (starts with 'glsa_')";
     protected override string ExpirationFormatDescription => "format yyyy-MM-dd followed by optional time part hh:mm:ss or empty for no expiration";
     protected override bool HasExpiration => true;
 
@@ -24,7 +22,7 @@ public class GrafanaApiKey : GenericAccessToken
         new KeyValuePair<string, string>( "staging", "dotnet-eng-grafana-staging.westus2.cloudapp.azure.com" )
     };
 
-    public GrafanaApiKey(ISystemClock clock, IConsole console) : base(clock, console)
+    public AzureManagedGrafanaApiKey(ISystemClock clock, IConsole console) : base(clock, console)
     {
     }
 
@@ -40,18 +38,14 @@ public class GrafanaApiKey : GenericAccessToken
 
     protected override bool ValidateToken(string token)
     {
-        try
+        // Azure Managed Grafana service account tokens start with "glsa_"
+        if (token.StartsWith("glsa_", StringComparison.Ordinal))
         {
-            string jsonString = Encoding.UTF8.GetString(Convert.FromBase64String(token));
-            JsonDocument json = JsonDocument.Parse(jsonString, new JsonDocumentOptions());
-            if (json.RootElement.TryGetProperty("n", out JsonElement keyName))
-                Console.WriteLine($"API key was entered with name {keyName}.");
-
+            Console.WriteLine("Azure Managed Grafana service account token validated successfully.");
             return true;
         }
-        catch
-        {
-            return false;
-        }
+
+        Console.WriteLine("Invalid token format. Azure Managed Grafana tokens must start with 'glsa_'.");
+        return false;
     }
 }


### PR DESCRIPTION
This PR updates the Secret Manager tooling and vault configs to use the new Azure Managed Grafana-specific secret type `azure-managed-grafana-api-key` in place of the self-hosted grafana token type `grafana-api-key`. 
The `grafana-api-token` is used by the DotNet.Status.Web application to post and update deployment annotations in Grafana, specifically when deployment starts and ends


Related Issue: https://dev.azure.com/dnceng/internal/_workitems/edit/10012