### PR TITLE
PAT Migration: dn-bot-dnceng-build-r-code-r-project-r-profile-r (dotneteng-status)

### DIFF
--- a/.vault-config/shared/dotneteng-status-secrets.yaml
+++ b/.vault-config/shared/dotneteng-status-secrets.yaml
@@ -14,8 +14,3 @@ app-insights-connection-string:
   type: text
   parameters:
     description: The connection string for application insights. Go to the Azure resource for application insights -> Configure -> Properties -> Get the connection string
-
-dn-bot-dnceng-build-r-code-r-project-r-profile-r:
-  type: text
-  parameters:
-    description: "DEPRECATED - Migrated to Managed Identity (dotneteng-status-identity). Pending cleanup."

--- a/.vault-config/shared/dotneteng-status-secrets.yaml
+++ b/.vault-config/shared/dotneteng-status-secrets.yaml
@@ -25,13 +25,10 @@ dn-bot-dnceng-workitems-rw:
       name: dn-bot-account-redmond
       location: helixkv
 
+# DEPRECATED (AB#10136): Migrated to dotneteng-status-identity Managed Identity.
+# Remove this entry and the corresponding Key Vault secrets after validating
+# the MI works in production.
 dn-bot-dnceng-build-r-code-r-project-r-profile-r:
-  type: azure-devops-access-token
+  type: text
   parameters:
-    organizations: dnceng
-    scopes: build code project profile
-    requiredScopes: Build (Read) Code (Read) Project (Read) Profile (Read)
-    domainAccountName: dn-bot
-    domainAccountSecret:
-      name: dn-bot-account-redmond
-      location: helixkv
+    description: "DEPRECATED - Migrated to Managed Identity (dotneteng-status-identity). Pending cleanup."

--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Production.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Production.json
@@ -29,5 +29,10 @@
     "KustoIngestionUri": "https://ingest-engsrvprod.westus.kusto.windows.net",
     "ManagedIdentityId": "d2580e46-e758-4778-a864-18f909438b45",
     "UseAzCliAuthentication": false
+  },
+  "AzureDevOps": {
+    "build-monitor/dnceng": {
+      "ManagedIdentityClientId": "b73bcdd4-aba9-40a7-af0c-f95b8eb5ab62"
+    }
   }
 }

--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Staging.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Staging.json
@@ -30,5 +30,10 @@
     "KustoIngestionUri": "https://ingest-engdata.westus2.kusto.windows.net",
     "ManagedIdentityId": "e9d81917-4c98-44cc-8a6e-601311ac3c07",
     "UseAzCliAuthentication": false
+  },
+  "AzureDevOps": {
+    "build-monitor/dnceng": {
+      "ManagedIdentityClientId": "8cd89985-08e4-4baa-86f1-76ee58b6b393"
+    }
   }
 }

--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
@@ -20,7 +20,6 @@
   "AzureDevOps": {
     "build-monitor/dnceng": {
       "Organization": "dnceng",
-      "AccessToken": "[vault(dn-bot-dnceng-build-r-code-r-project-r-profile-r)]",
       "MaxParallelRequests": 10
     },
     "dnceng": {


### PR DESCRIPTION
## Work Item
[AB#10136](https://dev.azure.com/dnceng/internal/_workitems/edit/10136) - PAT Migration: dn-bot-dnceng-build-r-code-r-project-r-profile-r

## Summary
Migrates the \dn-bot-dnceng-build-r-code-r-project-r-profile-r\ PAT used by the **dotneteng-status** web app (build monitor) to Entra bearer-token authentication using a new **dotneteng-status-identity** Managed Identity.

## Code Changes (4 files)

**Configuration:**
- **settings.json** — Removed \AccessToken\ vault reference from \uild-monitor/dnceng\ (MI will be used instead)
- **settings.Staging.json** — Added \AzureDevOps.build-monitor/dnceng.ManagedIdentityClientId\ = \8cd89985-08e4-4baa-86f1-76ee58b6b393\
- **settings.Production.json** — Added \AzureDevOps.build-monitor/dnceng.ManagedIdentityClientId\ = \73bcdd4-aba9-40a7-af0c-f95b8eb5ab62\

**Secret Manager:**
- **dotneteng-status-secrets.yaml** — Deprecated \dn-bot-dnceng-build-r-code-r-project-r-profile-r\ (changed to \	ype: text\ with deprecation notice)

## Azure Resources Provisioned (out-of-repo)

**Managed Identities Created:**
| Environment | MI Name | Client ID | Resource Group | Subscription |
| --- | --- | --- | --- | --- |
| Staging | dotneteng-status-identity | \8cd89985-08e4-4baa-86f1-76ee58b6b393\ | monitoring | \cab65fc3-...\ |
| Production | dotneteng-status-identity | \73bcdd4-aba9-40a7-af0c-f95b8eb5ab62\ | monitoring | \68672ab8-...\ |

**App Service MI Assignments:**
- \dotneteng-status-staging\ ← dotneteng-status-identity (staging)
- \dotneteng-status\ ← dotneteng-status-identity (production)

**Azure DevOps Organization Access (\dnceng\):**
| MI | AzDO SP Descriptor | Group |
| --- | --- | --- |
| Prod | \adsp.ZDMxNmY0MjQtMDIwNC03MWQyLWE3ZDctZmVmN2FmMjhiNDYw\ | [internal] Readers |
| Staging | \adsp.MTgwYWFkYTAtNTRjYi03NmFiLWIyMTYtZmM0MTUxMTg0NGNj\ | [internal] Readers |

## How It Works
The \AzureDevOpsClient\ already supports MI-based auth — when \ManagedIdentityClientId\ is set and \AccessToken\ is absent, it uses \ManagedIdentityCredential\ to acquire Entra bearer tokens for Azure DevOps. The existing \AzureDevOpsClient.PostDeploymentTests\ validate this code path.

## Post-Merge Cleanup
After validating the MI works in production:
1. Delete the deprecated \dn-bot-dnceng-build-r-code-r-project-r-profile-r\ entry from \dotneteng-status-secrets.yaml\
2. Remove the corresponding PAT secrets from Key Vaults (\dotneteng-status-prod\, \dotneteng-status-staging\, \dotneteng-status-local\)
3. Revoke the \dn-bot-dnceng-build-r-code-r-project-r-profile-r\ PAT from the \dn-bot\ Azure DevOps account
