### PR TITLE
Remove DevDiv Org - Repo Access PAT entry from secret manifest

### DIFF
--- a/.vault-config/service-connections-dnceng.yaml
+++ b/.vault-config/service-connections-dnceng.yaml
@@ -51,19 +51,6 @@ secrets:
           organizations: devdiv
           scopes: packaging
 
-  DevDiv Org - Repo Access:
-    type: azure-devops-service-endpoint
-    parameters:
-      authorization:
-        type: azure-devops-access-token
-        parameters:
-          domainAccountName: dn-bot
-          domainAccountSecret:
-            location: helixkv
-            name: dn-bot-account-redmond
-          organizations: devdiv
-          scopes: build_execute code_write
-
   azure-public/vssdk:
     type: azure-devops-service-endpoint
     parameters:


### PR DESCRIPTION
## Summary

Fully removes the `DevDiv Org - Repo Access` PAT entry from `.vault-config/service-connections-dnceng.yaml`.

## Reason

The only pipeline that consumed this service connection was **Fast Insertions** (pipeline definition 923) in `dnceng/internal/dotnet-release`. That pipeline is archived and disabled, so the PAT-based service connection is no longer needed.

## Related

- dnceng/internal WI [10127](https://dev.azure.com/dnceng/internal/_workitems/edit/10127) - PAT migration work item
- dnceng/internal WI [10358](https://dev.azure.com/dnceng/internal/_workitems/edit/10358) - Delete archived Fast Insertions pipeline

Per the secret manifest guidelines, the entry is fully deleted (not deprecated to `type: text`).