### PR TITLE
Fix null handling in DotNet.Status.Web alert hooks

### DIFF
--- a/src/DotNet.Status.Web/DotNet.Status.Web.Tests/AlertHookControllerTests.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web.Tests/AlertHookControllerTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Reflection;
+using AwesomeAssertions;
+using DotNet.Status.Web.Controllers;
+using DotNet.Status.Web.Models;
+using DotNet.Status.Web.Options;
+using Microsoft.DotNet.GitHub.Authentication;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Octokit;
+
+namespace DotNet.Status.Web.Tests;
+
+[TestFixture]
+public class AlertHookControllerTests
+{
+    [Test]
+    public void GenerateNewIssue_WithMissingEvalMatchesAndNotificationTargets_DoesNotThrow()
+    {
+        AlertHookController controller = CreateController(null);
+        GrafanaNotification notification = new GrafanaNotification
+        {
+            Title = "Alert title",
+            State = "alerting",
+            Message = "Something went wrong",
+            RuleUrl = "https://example/rule",
+            EvalMatches = null,
+        };
+
+        Action action = () => InvokeGenerateNewIssue(controller, notification);
+
+        action.Should().NotThrow();
+
+        NewIssue issue = InvokeGenerateNewIssue(controller, notification);
+        issue.Body.Should().Contain("Please investigate");
+        issue.Body.Should().NotContain(", please investigate");
+    }
+
+    [Test]
+    public void GenerateNewNotificationComment_WithMissingEvalMatches_DoesNotThrow()
+    {
+        AlertHookController controller = CreateController(Array.Empty<string>());
+        GrafanaNotification notification = new GrafanaNotification
+        {
+            Title = "Alert title",
+            State = "alerting",
+            Message = "Something went wrong",
+            RuleUrl = "https://example/rule",
+            EvalMatches = null,
+        };
+
+        Action action = () => InvokeGenerateNewNotificationComment(controller, notification);
+
+        action.Should().NotThrow();
+
+        string comment = InvokeGenerateNewNotificationComment(controller, notification);
+        comment.Should().Contain("Metric state changed to *alerting*");
+    }
+
+    private static AlertHookController CreateController(string[] notificationTargets)
+    {
+        Mock<IGitHubTokenProvider> tokenProvider = new(MockBehavior.Strict);
+        IOptions<GitHubConnectionOptions> githubOptions = Microsoft.Extensions.Options.Options.Create(new GitHubConnectionOptions
+        {
+            Organization = "dotnet",
+            Repository = "dnceng",
+            NotificationTargets = notificationTargets,
+            AlertLabels = Array.Empty<string>(),
+            EnvironmentLabels = Array.Empty<string>(),
+            TitlePrefix = "[test] ",
+            SupplementalBodyText = "Supplemental text",
+        });
+        IOptions<GitHubClientOptions> clientOptions = Microsoft.Extensions.Options.Options.Create(new GitHubClientOptions
+        {
+            ProductHeader = new ProductHeaderValue("DotNetStatusWebTests"),
+        });
+
+        return new AlertHookController(
+            tokenProvider.Object,
+            githubOptions,
+            clientOptions,
+            NullLogger<AlertHookController>.Instance);
+    }
+
+    private static NewIssue InvokeGenerateNewIssue(AlertHookController controller, GrafanaNotification notification)
+    {
+        MethodInfo method = typeof(AlertHookController).GetMethod("GenerateNewIssue", BindingFlags.Instance | BindingFlags.NonPublic);
+        method.Should().NotBeNull();
+
+        return (NewIssue)method.Invoke(controller, new object[] { notification });
+    }
+
+    private static string InvokeGenerateNewNotificationComment(AlertHookController controller, GrafanaNotification notification)
+    {
+        MethodInfo method = typeof(AlertHookController).GetMethod("GenerateNewNotificationComment", BindingFlags.Instance | BindingFlags.NonPublic);
+        method.Should().NotBeNull();
+
+        return (string)method.Invoke(controller, new object[] { notification });
+    }
+}

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/AlertHookController.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/AlertHookController.cs
@@ -120,12 +120,7 @@ public class AlertHookController : ControllerBase
 
     private string GenerateNewNotificationComment(GrafanaNotification notification)
     {
-        var metricText = new StringBuilder();
-        foreach (GrafanaNotificationMatch match in notification.EvalMatches)
-        {
-            metricText.AppendLine($"  - *{match.Metric}* {match.Value}");
-        }
-            
+        string metricText = BuildMetricText(notification);
         string icon = GetIcon(notification);
         string image = !string.IsNullOrEmpty(notification.ImageUrl) ? $"![Metric Graph]({notification.ImageUrl})" : string.Empty;
 
@@ -142,12 +137,7 @@ public class AlertHookController : ControllerBase
 
     private NewIssue GenerateNewIssue(GrafanaNotification notification)
     {
-        var metricText = new StringBuilder();
-        foreach (GrafanaNotificationMatch match in notification.EvalMatches)
-        {
-            metricText.AppendLine($"  - *{match.Metric}* {match.Value}");
-        }
-
+        string metricText = BuildMetricText(notification);
         string icon = GetIcon(notification);
         string image = !string.IsNullOrEmpty(notification.ImageUrl) ? $"![Metric Graph]({notification.ImageUrl})" : string.Empty;
 
@@ -159,6 +149,11 @@ public class AlertHookController : ControllerBase
         {
             issueTitle = prefix + issueTitle;
         }
+
+        string notificationMentions = string.Join(", ", options.NotificationTargets.OrEmpty().Select(target => $"@{target}"));
+        string investigationLine = string.IsNullOrEmpty(notificationMentions)
+            ? "Please investigate"
+            : $"{notificationMentions}, please investigate";
 
         var issue = new NewIssue(issueTitle)
         {
@@ -172,7 +167,7 @@ public class AlertHookController : ControllerBase
 
 [Go to rule]({notification.RuleUrl})
 
-{string.Join(", ", options.NotificationTargets.Select(target => $"@{target}"))}, please investigate
+{investigationLine}
 
 {options.SupplementalBodyText}
 
@@ -198,6 +193,18 @@ public class AlertHookController : ControllerBase
         }
 
         return issue;
+    }
+
+    private static string BuildMetricText(GrafanaNotification notification)
+    {
+        StringBuilder metricText = new StringBuilder();
+        IEnumerable<GrafanaNotificationMatch> matches = notification.EvalMatches ?? Enumerable.Empty<GrafanaNotificationMatch>();
+        foreach (GrafanaNotificationMatch match in matches)
+        {
+            metricText.AppendLine($"  - *{match.Metric}* {match.Value}");
+        }
+
+        return metricText.ToString();
     }
 
     private static string GetIcon(GrafanaNotification notification)


### PR DESCRIPTION
## Summary
- guard AlertHookController against null EvalMatches in alert issue/comment generation
- fall back cleanly when NotificationTargets is missing
- add regression tests for both null cases

AB#9360