### PR TITLE
Mark release-task jobs with templateContext type: releaseJob

### DIFF
--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -135,6 +135,8 @@ stages:
 
   - job: deployStatus
     displayName: Deploy dotnet-status web app
+    templateContext:
+      type: releaseJob
     pool:
       name: NetCore1ESPool-Internal-NoMSI
       demands: ImageOverride -equals 1es-windows-2022

--- a/eng/provision-grafana.yaml
+++ b/eng/provision-grafana.yaml
@@ -27,6 +27,8 @@ parameters:
 jobs:
 - job: ProvisionGrafana
   displayName: 'Provision Azure Managed Grafana'
+  templateContext:
+    type: releaseJob
   pool:
     name: NetCore1ESPool-Internal
     demands: ImageOverride -equals 1es-windows-2022


### PR DESCRIPTION
## Summary

Jobs `deployStatus` and `ProvisionGrafana` use release tasks (`AzureRmWebAppDeployment`, `AzureResourceManagerTemplateDeployment`) but were not marked as release jobs, causing 1ES PT non-blocking enforcement warnings in [build 2948290](https://dnceng.visualstudio.com/internal/_build/results?buildId=2948290&view=results).

## Changes

- **eng/deploy.yaml**: Added `templateContext: { type: releaseJob }` to the `deployStatus` job.
- **eng/provision-grafana.yaml**: Added `templateContext: { type: releaseJob }` to the `ProvisionGrafana` job.

## Reference

- [1ES PT release-tasks enforcement](https://aka.ms/1espt/release-tasks-enforcement)
- Fixes AB#10410