### PR TITLE
Fix 1ES PT release-task enforcement: use isProduction instead of type

### DIFF
--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -136,7 +136,7 @@ stages:
   - job: deployStatus
     displayName: Deploy dotnet-status web app
     templateContext:
-      type: releaseJob
+      isProduction: true
     pool:
       name: NetCore1ESPool-Internal-NoMSI
       demands: ImageOverride -equals 1es-windows-2022

--- a/eng/provision-grafana.yaml
+++ b/eng/provision-grafana.yaml
@@ -28,7 +28,7 @@ jobs:
 - job: ProvisionGrafana
   displayName: 'Provision Azure Managed Grafana'
   templateContext:
-    type: releaseJob
+    isProduction: true
   pool:
     name: NetCore1ESPool-Internal
     demands: ImageOverride -equals 1es-windows-2022


### PR DESCRIPTION
## Summary

Follow-up fix to PR #6498 which broke the build ([build 2950116](https://dnceng.visualstudio.com/internal/_build/results?buildId=2950116&view=results)).

The 1ES PT `ReleaseJob.yml` template requires `templateContext.isProduction: true`, not `templateContext.type: releaseJob`. The previous PR used the wrong property, causing:

\\\
/v1/Jobs/ReleaseJob.yml@1ESPipelineTemplates (Line: 73, Col: 5): Unexpected value
'A release job has to be classified using job.templateContext.isProduction flag
(see stage: 'deploy', job: 'deployStatus')'
\\\

## Changes

- **eng/deploy.yaml**: Changed `templateContext.type: releaseJob` to `templateContext.isProduction: true` on the `deployStatus` job.
- **eng/provision-grafana.yaml**: Changed `templateContext.type: releaseJob` to `templateContext.isProduction: true` on the `ProvisionGrafana` job.

## Reference

- Fixes AB#10410