### PR TITLE
Add templateContext.type: releaseJob to release-task jobs

### DIFF
--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -136,6 +136,7 @@ stages:
   - job: deployStatus
     displayName: Deploy dotnet-status web app
     templateContext:
+      type: releaseJob
       isProduction: true
     pool:
       name: NetCore1ESPool-Internal-NoMSI

--- a/eng/provision-grafana.yaml
+++ b/eng/provision-grafana.yaml
@@ -28,6 +28,7 @@ jobs:
 - job: ProvisionGrafana
   displayName: 'Provision Azure Managed Grafana'
   templateContext:
+    type: releaseJob
     isProduction: true
   pool:
     name: NetCore1ESPool-Internal


### PR DESCRIPTION
## Summary

Follow-up to PR #6498 and #6499. The 1ES PT enforcement check still flags `deployStatus` and `ProvisionGrafana` because the `Job.yml` router requires `templateContext.type: releaseJob` to route jobs to `ReleaseJob.yml`. Without it, jobs are treated as regular agent jobs and the \\Verify release tasks usage\\ post-build check continues to flag them.

PR #6499 added `isProduction: true` (which `ReleaseJob.yml` validates internally), but was missing `type: releaseJob`. Both are needed.

## Changes

- **eng/deploy.yaml**: Added `type: releaseJob` to `deployStatus` job's `templateContext`
- **eng/provision-grafana.yaml**: Added `type: releaseJob` to `ProvisionGrafana` job's `templateContext`

## Validation

Cannot validate on a branch build — the \\Verify release tasks usage (1ES PT)\\ check only runs on main. Confirmed by reading the [1ESPT Job.yml routing logic](https://dev.azure.com/dnceng/1ESPipelineTemplates/_git/1ESPipelineTemplates?path=/v1/Jobs/Job.yml) which requires \\	emplateContext.type: releaseJob\\ to invoke \\ReleaseJob.yml\\.

Fixes AB#10410