### PR TITLE
Replace download shorthand with 1ES.DownloadPipelineArtifact in deployStatus release job

### DIFF
--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -142,8 +142,10 @@ stages:
       name: NetCore1ESPool-Internal-NoMSI
       demands: ImageOverride -equals 1es-windows-2022
     steps:
-    - download: current
-      artifact: DotNetStatus
+    - task: 1ES.DownloadPipelineArtifact@1
+      inputs:
+        artifactName: DotNetStatus
+        targetPath: $(Pipeline.Workspace)/DotNetStatus
     - task: AzureRmWebAppDeployment@4
       inputs:
         ConnectionType: AzureRM


### PR DESCRIPTION
## Summary

Follow-up to PR #6501. Marking `deployStatus` as a `releaseJob` causes 1ES PT to apply stricter `UserProvidedReleaseSteps.yml` validation, which **disallows** the `- download:` step shorthand in release jobs ([build 2950938](https://dnceng.visualstudio.com/internal/_build/results?buildId=2950938&view=results)):

\\\
step '-download: artifact' is not allowed. Please use pipelineArtifact input
or 1ES.DownloadPipelineArtifact@1 task instead.
\\\

## Changes

- **eng/deploy.yaml**: Replaced `- download: current` with `1ES.DownloadPipelineArtifact@1` task in the `deployStatus` job.

## Reference

- [1ES PT inputs docs](https://aka.ms/1espt/inputs)
- Fixes AB#10410