### PR TITLE
Revert releaseJob from ProvisionGrafana (incompatible with checkout)

### DIFF
--- a/eng/provision-grafana.yaml
+++ b/eng/provision-grafana.yaml
@@ -27,9 +27,6 @@ parameters:
 jobs:
 - job: ProvisionGrafana
   displayName: 'Provision Azure Managed Grafana'
-  templateContext:
-    type: releaseJob
-    isProduction: true
   pool:
     name: NetCore1ESPool-Internal
     demands: ImageOverride -equals 1es-windows-2022


### PR DESCRIPTION
## Summary

Urgent fix — build [2951158](https://dnceng.visualstudio.com/internal/_build/results?buildId=2951158&view=results) is failing because `ProvisionGrafana` was marked as a `releaseJob` (PRs #6498/#6501) but it requires `checkout: self` to access Bicep templates. Release jobs disallow checkout (\\EnforceNoCheckout.yml\\):

\\\
Checkout is not allowed in release jobs. Please use job inputs instead.
\\\

\\ProvisionGrafana\\ provisions infrastructure — it's not releasing a built artifact — so it should not be a release job. The non-blocking 1ES PT warning for \\AzureResourceManagerTemplateDeployment\\ in this job is acceptable.

\\deployStatus\\ remains correctly marked as a \\eleaseJob\\ (it deploys a built .zip artifact and doesn't need checkout).

## Changes

- **eng/provision-grafana.yaml**: Removed `templateContext: { type: releaseJob, isProduction: true }` from `ProvisionGrafana`

Fixes AB#10410