### PR TITLE
Fix 1ES PT release-task enforcement for ProvisionGrafana

### DIFF
--- a/eng/provision-grafana.yaml
+++ b/eng/provision-grafana.yaml
@@ -25,12 +25,11 @@ parameters:
   type: string
 
 jobs:
-- job: ProvisionGrafana
-  displayName: 'Provision Azure Managed Grafana'
+- job: PrepareGrafanaBicep
+  displayName: 'Prepare Grafana Bicep Template'
   pool:
     name: NetCore1ESPool-Internal
     demands: ImageOverride -equals 1es-windows-2022
-  
   steps:
   - checkout: self
     displayName: 'Checkout Repository'
@@ -52,6 +51,29 @@ jobs:
           throw "Bicep template validation failed"
         }
         Write-Host "SUCCESS: Bicep template validation successful"
+
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish Bicep Template Artifact'
+    inputs:
+      targetPath: 'eng/deployment/azure-managed-grafana.bicep'
+      artifactName: 'GrafanaBicep'
+
+- job: ProvisionGrafana
+  displayName: 'Provision Azure Managed Grafana'
+  dependsOn: PrepareGrafanaBicep
+  templateContext:
+    type: releaseJob
+    isProduction: true
+  pool:
+    name: NetCore1ESPool-Internal
+    demands: ImageOverride -equals 1es-windows-2022
+  
+  steps:
+  - task: 1ES.DownloadPipelineArtifact@1
+    displayName: 'Download Bicep Template'
+    inputs:
+      artifactName: 'GrafanaBicep'
+      targetPath: $(Pipeline.Workspace)/GrafanaBicep
 
   - task: AzureCLI@2
     displayName: 'Ensure Resource Group Exists'
@@ -90,7 +112,7 @@ jobs:
       resourceGroupName: '${{ parameters.GrafanaResourceGroup }}'
       location: '${{ parameters.GrafanaLocation }}'
       templateLocation: 'Linked artifact'
-      csmFile: 'eng/deployment/azure-managed-grafana.bicep'
+      csmFile: '$(Pipeline.Workspace)/GrafanaBicep/azure-managed-grafana.bicep'
       overrideParameters: '-location "${{ parameters.GrafanaLocation }}" -grafanaWorkspaceName "${{ parameters.GrafanaWorkspaceName }}" -skuName "${{ parameters.GrafanaSkuName }}" -environment "${{ parameters.DeploymentEnvironment }}" -keyVaultName "${{ parameters.GrafanaKeyVault }}"'
       deploymentMode: 'Incremental'
       deploymentName: 'grafana-${{ parameters.DeploymentEnvironment }}-$(Build.BuildNumber)'


### PR DESCRIPTION
## Summary

Fixes the remaining 1ES PT non-blocking error for the \ProvisionGrafana\ job:

> Job 'ProvisionGrafana' uses the release tasks ["azureresourcemanagertemplatedeployment"] but is not marked as a release job.

## Approach

Split \ProvisionGrafana\ into two jobs:

1. **PrepareGrafanaBicep** — Non-release job that checks out the repo, validates the Bicep template, and publishes it as a pipeline artifact.
2. **ProvisionGrafana** — Marked as \eleaseJob\ with \isProduction: true\. Downloads the Bicep artifact via \1ES.DownloadPipelineArtifact@1\ instead of using \checkout: self\.

This follows the same pattern used for the \deployStatus\ job fix in #6503.

## Why previous attempts failed

Simply adding \	emplateContext: { type: releaseJob, isProduction: true }\ to \ProvisionGrafana\ caused a hard build failure because 1ES PT release jobs disallow \- checkout: self\ (enforced by \EnforceNoCheckout.yml\). The job needed checkout to access the Bicep template at \ng/deployment/azure-managed-grafana.bicep\.

## Related builds
- Build with both errors: https://dev.azure.com/dnceng/internal/_build/results?buildId=2950170
- Build with only this error remaining: https://dev.azure.com/dnceng/internal/_build/results?buildId=2951257