### PR TITLE
Fix PrepareGrafanaBicep: use templateContext.outputs for artifact publishing

### DIFF
--- a/eng/provision-grafana.yaml
+++ b/eng/provision-grafana.yaml
@@ -27,6 +27,12 @@ parameters:
 jobs:
 - job: PrepareGrafanaBicep
   displayName: 'Prepare Grafana Bicep Template'
+  templateContext:
+    outputs:
+      - output: pipelineArtifact
+        displayName: 'Publish Bicep Template Artifact'
+        targetPath: 'eng/deployment/azure-managed-grafana.bicep'
+        artifactName: 'GrafanaBicep'
   pool:
     name: NetCore1ESPool-Internal
     demands: ImageOverride -equals 1es-windows-2022
@@ -51,12 +57,6 @@ jobs:
           throw "Bicep template validation failed"
         }
         Write-Host "SUCCESS: Bicep template validation successful"
-
-  - task: PublishPipelineArtifact@1
-    displayName: 'Publish Bicep Template Artifact'
-    inputs:
-      targetPath: 'eng/deployment/azure-managed-grafana.bicep'
-      artifactName: 'GrafanaBicep'
 
 - job: ProvisionGrafana
   displayName: 'Provision Azure Managed Grafana'


### PR DESCRIPTION
## Summary

Fixes the template expansion failure in build 2952004 caused by #6506.

## Problem

1ES PT v1 disallows inline \PublishPipelineArtifact@1\ tasks in jobs. Artifact publishing must use \	emplateContext.outputs\ with \output: pipelineArtifact\. The previous PR (#6506) used the inline task form, causing the build to fail during YAML template expansion (no timeline or logs generated).

## Fix

Replaced the inline \PublishPipelineArtifact@1\ step in the \PrepareGrafanaBicep\ job with \	emplateContext.outputs\, matching the pattern used by the \Windows_NT\ build job in \zure-pipelines.yml\.

## Related
- Previous fix that introduced this: #6506
- Failed build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2952004