### PR TITLE
Fix PrepareGrafanaBicep SBOM: publish directory instead of single file

### DIFF
--- a/eng/provision-grafana.yaml
+++ b/eng/provision-grafana.yaml
@@ -31,7 +31,7 @@ jobs:
     outputs:
       - output: pipelineArtifact
         displayName: 'Publish Bicep Template Artifact'
-        targetPath: 'eng/deployment/azure-managed-grafana.bicep'
+        targetPath: $(Build.ArtifactStagingDirectory)/GrafanaBicep
         artifactName: 'GrafanaBicep'
   pool:
     name: NetCore1ESPool-Internal
@@ -57,6 +57,13 @@ jobs:
           throw "Bicep template validation failed"
         }
         Write-Host "SUCCESS: Bicep template validation successful"
+
+  - task: CopyFiles@2
+    displayName: 'Stage Bicep Template'
+    inputs:
+      SourceFolder: 'eng/deployment'
+      Contents: 'azure-managed-grafana.bicep'
+      TargetFolder: $(Build.ArtifactStagingDirectory)/GrafanaBicep
 
 - job: ProvisionGrafana
   displayName: 'Provision Azure Managed Grafana'


### PR DESCRIPTION
## Summary

Fixes SBOM validation failure in build 2952240 caused by #6507.

## Problem

1ES PT auto-injects SBOM generation and validation for pipeline artifacts. SBOM generation needs a **directory** to write its \_manifest/\ folder into. #6507 published a single file (\ng/deployment/azure-managed-grafana.bicep\) as the artifact \	argetPath\, so SBOM had nowhere to place the manifest:

\\\
No SBOM file found. Checked:
  D:\a\_work\1\GrafanaBicep\_manifest\spdx_2.2\manifest.spdx.json
  D:\a\_work\1\GrafanaBicep\_manifest\spdx_3.0\manifest.spdx.json
\\\

## Fix

1. Copy the Bicep file to a staging directory via \CopyFiles@2\
2. Publish the staging **directory** as the artifact

This matches how all other artifacts in \zure-pipelines.yml\ are published (they all use directories like \\\...\).

## Related
- Failed build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2952240
- Previous PRs: #6506, #6507