### PR TITLE
Fix graph color contrast to meet MAS 1.4.11 accessibility requirements

### DIFF
--- a/src/Monitoring/Monitoring.DncEng/dashboard/general/home.dashboard.json
+++ b/src/Monitoring/Monitoring.DncEng/dashboard/general/home.dashboard.json
@@ -490,7 +490,7 @@
           "visible": true
         }
       ],
-      "title": "Work Items Waiting Time (Test Queues).",
+      "title": "Work Items Waiting Time (Test Queues)",
       "type": "timeseries"
     },
     {

--- a/src/Monitoring/Monitoring.DncEng/dashboard/general/home.dashboard.json
+++ b/src/Monitoring/Monitoring.DncEng/dashboard/general/home.dashboard.json
@@ -160,7 +160,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
+                "color": "#767676",
                 "value": null
               },
               {
@@ -171,7 +171,38 @@
           },
           "unit": "m"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Percentile95"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0066CC",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Percentile50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#D84315",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 9,
@@ -335,7 +366,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
+                "color": "#767676",
                 "value": null
               },
               {
@@ -346,7 +377,38 @@
           },
           "unit": "m"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Percentile95"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0066CC",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Percentile50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#D84315",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 9,
@@ -428,7 +490,7 @@
           "visible": true
         }
       ],
-      "title": "Work Items Waiting Time (Test Queues)",
+      "title": "Work Items Waiting Time (Test Queues).",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
Related issue: https://dev.azure.com/dnceng/internal/_workitems/edit/10195

This PR addresses an accessibility violation in the Grafana home dashboard where graph elements had insufficient color contrast (1.545:1) against the background, falling below the required 3:1 minimum ratio specified by MAS 1.4.11 - Non-text Contrast.

**Changes Made**
Updated the graph color configuration in src/Monitoring/Monitoring.DncEng/dashboard/general/home.dashboard.json to use high-contrast colors that meet MAS 1.4.11 requirements:

For both "Work Items Waiting Time (Build Pools)" and "Work Items Waiting Time (Test Queues)" graphs:

1. **Threshold color**: Changed from &quot;transparent&quot; to &quot;#767676&quot; (medium gray)

- Provides a 4.54:1 contrast ratio against white backgrounds

2. **Percentile95 series**: Added explicit color override to &quot;#0066CC&quot; (accessible blue)
-  Provides a 5.57:1 contrast ratio against white backgrounds
-  Ensures the 95th percentile line is clearly visible

3. **Percentile50 series**: Added explicit color override to &quot;#D84315&quot; (accessible orange-red)
- Provides a 4.44:1 contrast ratio against white backgrounds
- Ensures the 50th percentile line is clearly distinguishable

The color overrides were implemented using Grafana's field configuration override mechanism, matching series by name (Percentile95 and Percentile50) and applying fixed colors instead of relying on the palette-classic scheme.