### PR TITLE
Fix build-monitor AzDO client: add missing UseManagedIdentity flag

### DIFF
--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Production.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Production.json
@@ -32,6 +32,7 @@
   },
   "AzureDevOps": {
     "build-monitor/dnceng": {
+      "UseManagedIdentity": true,
       "ManagedIdentityClientId": "b73bcdd4-aba9-40a7-af0c-f95b8eb5ab62"
     },
     "dnceng": {

--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Staging.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Staging.json
@@ -33,6 +33,7 @@
   },
   "AzureDevOps": {
     "build-monitor/dnceng": {
+      "UseManagedIdentity": true,
       "ManagedIdentityClientId": "8cd89985-08e4-4baa-86f1-76ee58b6b393"
     },
     "dnceng": {


### PR DESCRIPTION
## Problem

The PAT migration in PR #6490 removed the `AccessToken` (vault reference) for the `build-monitor/dnceng` AzDO client config and added `ManagedIdentityClientId`, but forgot to set `UseManagedIdentity: true`.

Without this flag, the `AzureDevOpsClient` constructor falls through to the "no auth configured" code path, sending unauthenticated requests to AzDO. AzDO returns an HTML login page instead of JSON, causing:

```
Newtonsoft.Json.JsonReaderException: Unexpected character encountered while parsing value: <
   at AzurePipelinesController.BuildComplete()
     → AzureDevOpsClient.GetProjectNameAsync()
     → ListProjectsAsync()
```

This resulted in 500 errors on `/api/azp/build-complete`, which caused the Build Monitor service hook (`439d5934`) to be `disabledBySystem` by AzDO.

### Confirmed via App Insights

Production logs from `DotNetEng-Status-Prod` App Insights show the exact warning from `AzureDevOpsClient.cs`:

```
No authentication configured for org dnceng. Requests may fail.
```

This fires on every app startup for the `build-monitor/dnceng` client instance.

## Fix

Add `UseManagedIdentity: true` to the `build-monitor/dnceng` section in both `settings.Production.json` and `settings.Staging.json`.

This will cause the `AzureDevOpsClient` constructor to use the already-configured user-assigned Managed Identity (client ID `b73bcdd4-aba9-40a7-af0c-f95b8eb5ab62`) to acquire bearer tokens for AzDO API calls. The existing AzDO service hook (`BuildMonitorWebhook-dnceng`, ID `439d5934-8e89-4407-8e31-5b04d58b7854`) does not need credential changes — its inbound Basic auth to `/api/azp/build-complete` is handled separately and is working correctly. The 500 errors were caused by the **outbound** calls the controller makes back to AzDO to resolve project names and fetch build details, which is what this fix addresses.

## Follow-up

After this deploys, the service hook needs to be re-enabled manually:
1. Go to https://dev.azure.com/dnceng/internal/_settings/serviceHooks
2. Find the `build.complete` hook pointing to `dotneteng-status.azurewebsites.net/api/azp/build-complete` (currently `disabledBySystem`)
3. Edit and re-enable it
4. Use the "Test" button to verify it returns 204

Related: AzDO WI 10538