### PR TITLE
Fix packaging AzDO PAT generation

### DIFF
--- a/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/AzureDevOpsAccessToken.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/AzureDevOpsAccessToken.cs
@@ -118,14 +118,18 @@ public class AzureDevOpsAccessToken : SecretType<AzureDevOpsAccessToken.Paramete
         Console.WriteLine($"Creating new pat in orgs '{string.Join(" ", orgIds)}' with scopes '{string.Join(" ", scopes)}'");
         var rotatesOn = now.AddDays(1);
         var expiresOn = now.AddDays(3);
-        var newToken = await tokenClient.CreateSessionTokenAsync(new SessionToken
-        {
-            DisplayName = $"{context.SecretName} {now:u}",
-            Scope = string.Join(" ", scopes),
-            ValidFrom = now.UtcDateTime,
-            ValidTo = expiresOn.UtcDateTime,
-            TargetAccounts = orgIds,
-        }, cancellationToken: cancellationToken);
+        var newToken = await tokenClient.CreateSessionTokenAsync(
+            new SessionToken
+            {
+                DisplayName = $"{context.SecretName} {now:u}",
+                Scope = string.Join(" ", scopes),
+                ValidFrom = now.UtcDateTime,
+                ValidTo = expiresOn.UtcDateTime,
+                TargetAccounts = orgIds,
+            },
+            // For nuget feed PATs, they are the only ones allowed that can be a regular PAT. Others will just be a session token (shorter lifetime)
+            tokenType: scopes.Length == 1 && scopes.First() == "vso.packaging" ? SessionTokenType.Compact : null,
+            cancellationToken: cancellationToken);
 
         if (expiresOn - newToken.ValidTo > TimeSpan.FromDays(1))
         {


### PR DESCRIPTION
A recent change in how AzDO generates tokens (to Entra) meant that tokens started to be capped at around 1 hour.
For packaging PATs, we are still able to generate them regularly but we have to supply token type "compact" to get a PAT with the desired lifetime.