### PR TITLE
Fix TimelineBuilds ingestion: add UseManagedIdentity to AzureDevOpsTimeline config

### DIFF
--- a/src/Telemetry/AzureDevOpsTimeline/.config/settings.Production.json
+++ b/src/Telemetry/AzureDevOpsTimeline/.config/settings.Production.json
@@ -5,9 +5,11 @@
     },
     "AzureDevOpsSettings": {
         "dnceng": {
+            "UseManagedIdentity": true,
             "ManagedIdentityClientId": "13eb78dc-2e79-4ae1-afbf-f95c5b1d2a4c"
         },
         "dnceng-public": {
+            "UseManagedIdentity": true,
             "ManagedIdentityClientId": "13eb78dc-2e79-4ae1-afbf-f95c5b1d2a4c"
         }
     },

--- a/src/Telemetry/AzureDevOpsTimeline/.config/settings.Staging.json
+++ b/src/Telemetry/AzureDevOpsTimeline/.config/settings.Staging.json
@@ -5,9 +5,11 @@
     },
     "AzureDevOpsSettings": {
         "dnceng": {
+            "UseManagedIdentity": true,
             "ManagedIdentityClientId": "c05abe9e-b183-4c19-a7c3-6512f976548f"
         },
         "dnceng-public": {
+            "UseManagedIdentity": true,
             "ManagedIdentityClientId": "c05abe9e-b183-4c19-a7c3-6512f976548f"
         }
     },


### PR DESCRIPTION
## Problem

The TimelineBuilds Kusto table stopped receiving new data on April 1, 2026. The AzureDevOpsTimeline telemetry service was unable to authenticate to Azure DevOps after the PAT migration (WI 10135, commit b3251c7).

## Root Cause

The PAT migration added `ManagedIdentityClientId` to the `AzureDevOpsSettings` config but **omitted the `UseManagedIdentity: true` flag**. The `AzureDevOpsClient` constructor gates on this boolean:

`csharp
else if (options.UseManagedIdentity)   // <-- never entered
{
    if (!string.IsNullOrEmpty(options.ManagedIdentityClientId)) { ... }
}
else
{
    _logger.LogWarning("No authentication configured for org {organization}. Requests may fail.");
}
`

Without the flag, the MI auth path is skipped entirely, no `Authorization` header is set, and AzDO returns the HTML sign-in page instead of JSON, causing a `JsonReaderException`.

## Fix

Add `UseManagedIdentity: true` to both `dnceng` and `dnceng-public` entries in:
- `settings.Production.json`
- `settings.Staging.json`

## Validation

After merge and deploy, the TelemetryApplication should:
1. Log `Using user-assigned Managed Identity (ClientId: ...)` instead of `No authentication configured`
2. Begin backfilling TimelineBuilds from the April 1 watermark (~1000 builds/cycle)

Related: First Responders thread, WI 10135, DNCENG Task 10698