### PR TITLE
[Hotfix] Fix TimelineBuilds ingestion: add UseManagedIdentity to AzureDevOpsTimeline config

### DIFF
--- a/src/Telemetry/AzureDevOpsTimeline/.config/settings.Production.json
+++ b/src/Telemetry/AzureDevOpsTimeline/.config/settings.Production.json
@@ -5,9 +5,11 @@
     },
     "AzureDevOpsSettings": {
         "dnceng": {
+            "UseManagedIdentity": true,
             "ManagedIdentityClientId": "13eb78dc-2e79-4ae1-afbf-f95c5b1d2a4c"
         },
         "dnceng-public": {
+            "UseManagedIdentity": true,
             "ManagedIdentityClientId": "13eb78dc-2e79-4ae1-afbf-f95c5b1d2a4c"
         }
     },

--- a/src/Telemetry/AzureDevOpsTimeline/.config/settings.Staging.json
+++ b/src/Telemetry/AzureDevOpsTimeline/.config/settings.Staging.json
@@ -5,9 +5,11 @@
     },
     "AzureDevOpsSettings": {
         "dnceng": {
+            "UseManagedIdentity": true,
             "ManagedIdentityClientId": "c05abe9e-b183-4c19-a7c3-6512f976548f"
         },
         "dnceng-public": {
+            "UseManagedIdentity": true,
             "ManagedIdentityClientId": "c05abe9e-b183-4c19-a7c3-6512f976548f"
         }
     },


### PR DESCRIPTION
## Hotfix for Production

Same fix as #6540 (targeting main), cherry-picked to the production branch for immediate deployment.

**Problem:** TimelineBuilds Kusto table stopped updating April 1 because the PAT migration (WI 10135) added `ManagedIdentityClientId` but omitted `UseManagedIdentity: true`. Without the flag, AzureDevOpsClient skips MI auth entirely.

**Fix:** Add `UseManagedIdentity: true` to both `dnceng` and `dnceng-public` in Production and Staging configs.

**After deploy:** Service will log `Using user-assigned Managed Identity` and begin backfilling ~1000 builds/cycle.

Related: First Responders thread, WI 10135, DNCENG Task 10698, #6540