### PR TITLE
[PAT Migration] Remove devdiv/engineering PAT from secret manifest (WI 10126)

### DIFF
--- a/.vault-config/service-connections-dnceng.yaml
+++ b/.vault-config/service-connections-dnceng.yaml
@@ -38,18 +38,6 @@ secrets:
           organizations: devdiv
           scopes: packaging_write
 
-  devdiv/engineering:
-    type: azure-devops-service-endpoint
-    parameters:
-      authorization:
-        type: azure-devops-access-token
-        parameters:
-          domainAccountName: dn-bot
-          domainAccountSecret:
-            location: helixkv
-            name: dn-bot-account-redmond
-          organizations: devdiv
-          scopes: packaging
 
   azure-public/vssdk:
     type: azure-devops-service-endpoint


### PR DESCRIPTION
Remove the `devdiv/engineering` PAT entry from `.vault-config/service-connections-dnceng.yaml`. This SC has been migrated to WIF (`devdiv-engineering-feed-r-wif`).

Per policy: fully delete PAT entries from the secret manifest, do not deprecate to `type: text`.

Part of PAT migration [WI 10126](https://dev.azure.com/dnceng/internal/_workitems/edit/10126).