### PR TITLE
Fix AlertHookController 401 by adding webhook secret auth

### DIFF
--- a/.vault-config/dotneteng-status-local.yaml
+++ b/.vault-config/dotneteng-status-local.yaml
@@ -24,3 +24,9 @@ secrets:
     parameters:
       environment: dotnet-eng-grafana-staging.westus2.cloudapp.azure.com
 
+  # Shared secret for Grafana webhook contact point Basic Auth
+  grafana-webhook-secret:
+    type: text
+    parameters:
+      description: The Basic Auth password configured in Grafana contact points for alert webhook delivery
+

--- a/.vault-config/dotneteng-status-prod.yaml
+++ b/.vault-config/dotneteng-status-prod.yaml
@@ -24,6 +24,12 @@ secrets:
     type: azure-managed-grafana-api-key
     parameters:
       environment: dotnet-eng-grafana.westus2.cloudapp.azure.com
+
+  # Shared secret for Grafana webhook contact point Basic Auth
+  grafana-webhook-secret:
+    type: text
+    parameters:
+      description: The Basic Auth password configured in Grafana contact points for alert webhook delivery
   
   build-monitor-hook-dotnet-eng-status-token:
     type: text

--- a/.vault-config/dotneteng-status-staging.yaml
+++ b/.vault-config/dotneteng-status-staging.yaml
@@ -24,3 +24,9 @@ secrets:
     type: azure-managed-grafana-api-key
     parameters:
       environment: dotnet-eng-grafana-staging.westus2.cloudapp.azure.com
+
+  # Shared secret for Grafana webhook contact point Basic Auth
+  grafana-webhook-secret:
+    type: text
+    parameters:
+      description: The Basic Auth password configured in Grafana contact points for alert webhook delivery

--- a/src/DotNet.Status.Web/DotNet.Status.Web.Tests/AlertHookControllerTests.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web.Tests/AlertHookControllerTests.cs
@@ -77,10 +77,16 @@ public class AlertHookControllerTests
             ProductHeader = new ProductHeaderValue("DotNetStatusWebTests"),
         });
 
+        IOptions<GrafanaOptions> grafanaOptions = Microsoft.Extensions.Options.Options.Create(new GrafanaOptions
+        {
+            WebhookSecret = "test-secret",
+        });
+
         return new AlertHookController(
             tokenProvider.Object,
             githubOptions,
             clientOptions,
+            grafanaOptions,
             NullLogger<AlertHookController>.Instance);
     }
 

--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
@@ -291,7 +291,8 @@
   "Grafana": {
     "BaseUrl": "https://dotnet-eng-grafana-staging.westus2.cloudapp.azure.com",
     "ApiToken": "[vault(grafana-api-token)]",
-    "TableName": "deployments"
+    "TableName": "deployments",
+    "WebhookSecret": "[vault(grafana-webhook-secret)]"
   },
   "WebHooks": {
     "github": {

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/AlertHookController.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/AlertHookController.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DotNet.Status.Web.Models;
 using DotNet.Status.Web.Options;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.DotNet.GitHub.Authentication;
 using Microsoft.Extensions.Logging;
@@ -19,6 +21,7 @@ namespace DotNet.Status.Web.Controllers;
 
 [ApiController]
 [Route("api/alert")]
+[AllowAnonymous]
 public class AlertHookController : ControllerBase
 {
     public const string NotificationIdLabel = "Grafana Alert";
@@ -32,6 +35,7 @@ public class AlertHookController : ControllerBase
 
     private readonly IOptions<GitHubConnectionOptions> _githubOptions;
     private readonly IOptions<GitHubClientOptions> _githubClientOptions;
+    private readonly IOptions<GrafanaOptions> _grafanaOptions;
     private readonly ILogger _logger;
     private readonly IGitHubTokenProvider _tokenProvider;
 
@@ -39,17 +43,25 @@ public class AlertHookController : ControllerBase
         IGitHubTokenProvider tokenProvider,
         IOptions<GitHubConnectionOptions> githubOptions,
         IOptions<GitHubClientOptions> githubClientOptions,
+        IOptions<GrafanaOptions> grafanaOptions,
         ILogger<AlertHookController> logger)
     {
         _tokenProvider = tokenProvider;
         _githubOptions = githubOptions;
         _githubClientOptions = githubClientOptions;
+        _grafanaOptions = grafanaOptions;
         _logger = logger;
     }
 
     [HttpPost]
     public async Task<IActionResult> NotifyAsync(GrafanaNotification notification)
     {
+        if (!IsAuthorized())
+        {
+            _logger.LogWarning("Unauthorized alert webhook request received");
+            return Unauthorized();
+        }
+
         switch (notification.State)
         {
             case "ok":
@@ -349,5 +361,45 @@ public class AlertHookController : ControllerBase
         {
             Credentials = new Credentials(await _tokenProvider.GetTokenForRepository(org, repo))
         };
+    }
+
+    private bool IsAuthorized()
+    {
+        string webhookSecret = _grafanaOptions.Value?.WebhookSecret;
+        if (string.IsNullOrEmpty(webhookSecret))
+        {
+            _logger.LogError("Grafana WebhookSecret is not configured; rejecting request");
+            return false;
+        }
+
+        string authHeader = Request.Headers["Authorization"];
+        if (string.IsNullOrEmpty(authHeader))
+        {
+            return false;
+        }
+
+        if (!authHeader.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        try
+        {
+            string encoded = authHeader.Substring("Basic ".Length).Trim();
+            string decoded = Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
+            // Basic Auth format is "username:password" — we only validate the password
+            int colonIndex = decoded.IndexOf(':');
+            if (colonIndex < 0)
+            {
+                return false;
+            }
+
+            string password = decoded.Substring(colonIndex + 1);
+            return string.Equals(password, webhookSecret, StringComparison.Ordinal);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
     }
 }

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/AlertHookController.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/AlertHookController.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -365,39 +366,40 @@ public class AlertHookController : ControllerBase
 
     private bool IsAuthorized()
     {
-        string webhookSecret = _grafanaOptions.Value?.WebhookSecret;
-        if (string.IsNullOrEmpty(webhookSecret))
+        var secret = _grafanaOptions.Value?.WebhookSecret;
+        if (string.IsNullOrEmpty(secret))
         {
             _logger.LogError("Grafana WebhookSecret is not configured; rejecting request");
             return false;
         }
 
-        string authHeader = Request.Headers["Authorization"];
-        if (string.IsNullOrEmpty(authHeader))
-        {
+        if (!Request.Headers.TryGetValue("Authorization", out var authHeader))
             return false;
-        }
 
-        if (!authHeader.StartsWith("Basic ", StringComparison.OrdinalIgnoreCase))
-        {
+        if (!authHeader.ToString().StartsWith("Basic ", StringComparison.OrdinalIgnoreCase))
             return false;
-        }
 
         try
         {
-            string encoded = authHeader.Substring("Basic ".Length).Trim();
-            string decoded = Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
-            // Basic Auth format is "username:password" — we only validate the password
-            int colonIndex = decoded.IndexOf(':');
-            if (colonIndex < 0)
-            {
-                return false;
-            }
+            var encoded = authHeader.ToString().Substring("Basic ".Length).Trim();
+            var bytes = Convert.FromBase64String(encoded);
 
-            string password = decoded.Substring(colonIndex + 1);
-            return string.Equals(password, webhookSecret, StringComparison.Ordinal);
+            try
+            {
+                int colon = Array.IndexOf(bytes, (byte)':');
+                if (colon < 0) return false;
+
+                var provided = bytes.AsSpan(colon + 1);
+                var expected = Encoding.UTF8.GetBytes(secret);
+
+                return CryptographicOperations.FixedTimeEquals(provided, expected);
+            }
+            finally
+            {
+                Array.Clear(bytes, 0, bytes.Length);
+            }
         }
-        catch (FormatException)
+        catch
         {
             return false;
         }

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Options/GrafanaOptions.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Options/GrafanaOptions.cs
@@ -10,4 +10,5 @@ public class GrafanaOptions
     public string ApiToken { get; set; }
     public string TableUri { get; set; }
     public string TableName { get; set; }
+    public string WebhookSecret { get; set; }
 }


### PR DESCRIPTION
## Summary

The AlertHookController was returning 401 for all Grafana webhook requests because it fell under the default `msft` authorization policy requiring GitHub OAuth team membership. Grafana contact points use Basic Auth (username + password), which doesn't satisfy this policy.

This has been causing ~96 failed requests/hour since the May 13 production rollout.

## Changes

- Add `[AllowAnonymous]` to `AlertHookController` to bypass the default OAuth policy
- Add `IsAuthorized()` method that validates the Basic Auth password against a configured webhook secret from Key Vault
- Add `WebhookSecret` property to `GrafanaOptions`
- Add vault reference in `settings.json` for `grafana-webhook-secret`
- Update test to pass new `GrafanaOptions` parameter

## Deployment Steps

1. Retrieve the current Grafana contact point Basic Auth password (from Grafana API or admin UI)
2. Store it as `grafana-webhook-secret` in the dotneteng-status service's Key Vault
3. Deploy this change
4. Verify 401s stop in App Insights and alerts flow through to GitHub issues

## Related

- AzDO Work Item: https://dev.azure.com/dnceng/internal/_workitems/edit/10716
- Grafana contact points: `.NET Status Alert` (uid: ff54hqdata2gwf) and no-image variant (uid: df54hqd2wln28b)