### PR TITLE
Reduce GitHub PAT rotation interval from 60 to 30 days

### DIFF
--- a/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/GitHubAccessToken.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/GitHubAccessToken.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DncEng.SecretManager.SecretTypes;
 [Name("github-access-token")]
 public class GitHubAccessToken : GitHubAccountInteractiveSecretType<GitHubAccessToken.Parameters>
 {
-    private const int _nextRotationOnDeltaDays = 60;
+    private const int _nextRotationOnDeltaDays = 30;
     private const int _expirationInDays = 90;
 
     public class Parameters


### PR DESCRIPTION
## Summary

Reduces the _nextRotationOnDeltaDays from 60 to 30 days for GitHub PAT secrets.

## Problem

The previous 60-day rotation interval left only a 30-day buffer before the 90-day PAT expiration on GitHub. If manual rotations or timing drift caused mismatches between the KeyVault \
ext-rotation-on\ tag and the actual PAT expiry, builds would fail unexpectedly (as seen with BotAccount-dotnet-bot-repo-PAT).

## Fix

By rotating every 30 days instead of 60, we get a 60-day buffer before expiry, making it much less likely that a PAT expires before secret-manager triggers rotation.

## Related

- https://dev.azure.com/dnceng/internal/_workitems/edit/9752