### PR TITLE
Fix DotNet.Status.Web version and app_offline.htm leftover

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -180,6 +180,9 @@ extends:
               displayName: Copy Telemetry Project Artifacts
               
             - script: $(Build.SourcesDirectory)\.dotnet\dotnet publish -o $(Build.ArtifactStagingDirectory)\DotNet.Status.Web\publish -f net8.0
+                -c $(_BuildConfig)
+                /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+                /p:VersionPrefix=$(VersionPrefix)
               workingDirectory: src\DotNet.Status.Web\DotNet.Status.Web
               displayName: dotnet publish DotNet.Status.Web
 

--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -159,6 +159,7 @@ stages:
         enableCustomDeployment: true
         DeploymentType: zipDeploy
         RemoveAdditionalFilesFlag: true
+        TakeAppOfflineFlag: false
 
 - template: /eng/deploy-managed-grafana.yml@self
   parameters:


### PR DESCRIPTION
## Summary

Fixes two issues with the DotNet.Status.Web deployment (work item [8535](https://dev.azure.com/dnceng/internal/_workitems/edit/8535)):

### 1. Version always shows 42.42.42.42424

The dotnet publish step for DotNet.Status.Web didn't pass version properties, so Arcade SDK used its placeholder version. Now passes OfficialBuildId, VersionPrefix, and build configuration.

### 2. app_offline.htm leftover after deployment

The AzureRmWebAppDeployment@4 task defaults TakeAppOfflineFlag to true, which creates app_offline.htm during deploy. With zipDeploy this is unnecessary (the deploy is atomic) and intermittently the file isn't cleaned up, leaving the app offline. Setting TakeAppOfflineFlag: false prevents this.

## Changes

- azure-pipelines.yml: Pass version and config properties to dotnet publish
- eng/deploy.yaml: Set TakeAppOfflineFlag: false on web app deployment task