### PR TITLE
Set PCS staging alert noDataState to OK (fixes perpetual firing)

### DIFF
--- a/src/Monitoring/Monitoring.DncEng/alertrules/Staging/pcs-background-worker-stopped.alert.json
+++ b/src/Monitoring/Monitoring.DncEng/alertrules/Staging/pcs-background-worker-stopped.alert.json
@@ -119,7 +119,7 @@
       }
     }
   ],
-  "noDataState": "Alerting",
+  "noDataState": "OK",
   "execErrState": "Alerting",
   "for": "5m",
   "frequency": "1m",


### PR DESCRIPTION
## Problem

The PCS Background Worker Stopped alert has been firing in staging since **March 13** (~10 weeks). The staging PCS environment does not process work items, so \WorkItemExecuted\ telemetry is always empty. With \
oDataState: Alerting\, the alert fires indefinitely.

Premek's team silenced it manually, but rollouts reverted the silence since it was stored in Grafana's runtime state, not in the provisioned config.

## Fix

Change \
oDataState\ from \Alerting\ to \OK\ in the **Staging** alert rule file only.

- **Staging**: \OK\ — no alert when there's no telemetry data (expected state)
- **Production**: unchanged at \Alerting\ — still alerts if prod stops emitting

This persists across rollouts because it's in the source-of-truth config file.

## Related

- WI: https://dnceng.visualstudio.com/internal/_workitems/edit/10774
- Premek's feedback: staging has no work items, silencing gets reverted on deploy