### PR TITLE
Build Monitor: Create AzDO work items instead of GitHub issues for dnceng pipelines

### DIFF
--- a/src/DotNet.Status.Web/DotNet.Status.Web.Tests/AzurePipelinesControllerAzDoTests.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web.Tests/AzurePipelinesControllerAzDoTests.cs
@@ -1,0 +1,323 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNet.Status.Web.Controllers;
+using DotNet.Status.Web.Options;
+using Microsoft.DotNet.GitHub.Authentication;
+using Microsoft.DotNet.Internal.AzureDevOps;
+using Microsoft.DotNet.Internal.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace DotNet.Status.Web.Tests;
+
+[TestFixture]
+public class AzurePipelinesControllerAzDoTests
+{
+    private static AzurePipelinesController.AzureDevOpsEvent<AzurePipelinesController.AzureDevOpsMinimalBuildResource> CreateBuildEvent()
+    {
+        return new AzurePipelinesController.AzureDevOpsEvent<AzurePipelinesController.AzureDevOpsMinimalBuildResource>
+        {
+            Resource = new AzurePipelinesController.AzureDevOpsMinimalBuildResource
+            {
+                Id = 999,
+                Url = "test-build-url"
+            },
+            ResourceContainers = new AzurePipelinesController.AzureDevOpsResourceContainers
+            {
+                Collection = new AzurePipelinesController.HasId { Id = "collection-id" },
+                Account = new AzurePipelinesController.HasId { Id = "account-id" },
+                Project = new AzurePipelinesController.HasId { Id = "project-id" }
+            }
+        };
+    }
+
+    private static JObject CreateBuildJson(string definitionName = "test-pipeline", string branch = "refs/heads/main")
+    {
+        return new JObject
+        {
+            ["_links"] = new JObject { ["web"] = new JObject { ["href"] = "https://dev.azure.com/dnceng/internal/_build/results?buildId=999" } },
+            ["buildNumber"] = "20260522.1",
+            ["definition"] = new JObject { ["name"] = definitionName, ["path"] = "\\test" },
+            ["finishTime"] = "05/22/2026 12:00:00",
+            ["id"] = "999",
+            ["project"] = new JObject { ["name"] = "internal" },
+            ["reason"] = "schedule",
+            ["requestedFor"] = new JObject { ["displayName"] = "Build Agent" },
+            ["result"] = "failed",
+            ["sourceBranch"] = branch,
+            ["startTime"] = "05/22/2026 11:30:00",
+        };
+    }
+
+    private static BuildMonitorOptions CreateOptionsWithAzDoTarget()
+    {
+        return new BuildMonitorOptions
+        {
+            Monitor = new BuildMonitorOptions.AzurePipelinesOptions
+            {
+                Organization = "dnceng",
+                Builds = new[]
+                {
+                    new BuildMonitorOptions.AzurePipelinesOptions.BuildDescription
+                    {
+                        Project = "internal",
+                        DefinitionPath = "\\test\\test-pipeline",
+                        Branches = new[] { "main" },
+                        IssuesId = "azdo-fr-target"
+                    }
+                }
+            },
+            Issues = new BuildMonitorOptions.IssuesOptions[0],
+            AzDoIssues = new[]
+            {
+                new BuildMonitorOptions.AzDoIssuesOptions
+                {
+                    Id = "azdo-fr-target",
+                    Project = "internal",
+                    AreaPath = "internal\\.NET Engineering Services\\First Responders",
+                    WorkItemType = "DNCENG Task",
+                    Tags = new[] { "Ops - First Responder" },
+                    UpdateExisting = true
+                }
+            }
+        };
+    }
+
+    private (AzurePipelinesController controller, Mock<IAzureDevOpsClient> mockClient) CreateController(
+        BuildMonitorOptions options, JObject buildJson)
+    {
+        var mockClient = new Mock<IAzureDevOpsClient>();
+        mockClient.Setup(m => m.GetProjectNameAsync("project-id"))
+            .Returns(Task.FromResult("internal"));
+
+        if (buildJson != null)
+        {
+            var build = JsonConvert.DeserializeObject<Build>(buildJson.ToString());
+            mockClient.Setup(m => m.GetBuildAsync(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(build));
+        }
+
+        mockClient.Setup(m => m.GetBuildChangesAsync(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(((BuildChange[] changes, int? truncatedChangeCount)?)(new BuildChange[0], 0)));
+        mockClient.Setup(m => m.GetTimelineAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(new Timeline()));
+
+        mockClient.Setup(m => m.CreateWorkItemAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(new WorkItem { Id = 12345 }));
+
+        mockClient.Setup(m => m.QueryWorkItemsAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(new WorkItem[0]));
+
+        mockClient.Setup(m => m.AddWorkItemCommentAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var mockGithubClientFactory = new Mock<IGitHubApplicationClientFactory>();
+        var clientFactory = new SingleClientFactory<IAzureDevOpsClient>(mockClient.Object);
+        var optionsSnapshot = new Mock<IOptionsSnapshot<BuildMonitorOptions>>();
+        optionsSnapshot.Setup(o => o.Value).Returns(options);
+
+        var controller = new AzurePipelinesController(
+            mockGithubClientFactory.Object,
+            clientFactory,
+            optionsSnapshot.Object,
+            NullLogger<AzurePipelinesController>.Instance);
+
+        return (controller, mockClient);
+    }
+
+    [Test]
+    public async Task BuildComplete_AzDoTarget_CreatesNewWorkItem()
+    {
+        var options = CreateOptionsWithAzDoTarget();
+        var buildJson = CreateBuildJson();
+        var (controller, mockClient) = CreateController(options, buildJson);
+
+        var result = await controller.BuildComplete(CreateBuildEvent());
+
+        mockClient.Verify(m => m.CreateWorkItemAsync(
+            "internal",
+            "DNCENG Task",
+            It.Is<Dictionary<string, string>>(d =>
+                d["System.Title"].StartsWith("Build failed: test-pipeline/main") &&
+                d["System.Description"].Contains("20260522.1") &&
+                d["System.State"] == "Backlog" &&
+                d["System.Tags"].Contains("Build Failed") &&
+                d["System.Tags"].Contains("Ops - First Responder")),
+            "internal\\.NET Engineering Services\\First Responders",
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task BuildComplete_AzDoTarget_UpdateExisting_AddsComment()
+    {
+        var options = CreateOptionsWithAzDoTarget();
+        var buildJson = CreateBuildJson();
+        var (controller, mockClient) = CreateController(options, buildJson);
+
+        // Simulate existing work item found
+        mockClient.Setup(m => m.QueryWorkItemsAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(new[] { new WorkItem { Id = 42 } }));
+
+        var result = await controller.BuildComplete(CreateBuildEvent());
+
+        // Should add comment, not create new work item
+        mockClient.Verify(m => m.AddWorkItemCommentAsync(
+            "internal", 42, It.Is<string>(s => s.Contains("20260522.1")), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        mockClient.Verify(m => m.CreateWorkItemAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(),
+            It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task BuildComplete_AzDoTarget_UpdateExisting_NoMatch_CreatesNew()
+    {
+        var options = CreateOptionsWithAzDoTarget();
+        var buildJson = CreateBuildJson();
+        var (controller, mockClient) = CreateController(options, buildJson);
+
+        // No existing work items found
+        mockClient.Setup(m => m.QueryWorkItemsAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(new WorkItem[0]));
+
+        var result = await controller.BuildComplete(CreateBuildEvent());
+
+        mockClient.Verify(m => m.CreateWorkItemAsync(
+            "internal", "DNCENG Task", It.IsAny<Dictionary<string, string>>(),
+            "internal\\.NET Engineering Services\\First Responders",
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task BuildComplete_AzDoTarget_PrioritizedOverGitHub()
+    {
+        // If both a GitHub issue target and AzDo target exist with the same ID, AzDo wins
+        var options = CreateOptionsWithAzDoTarget();
+        options.Issues = new[]
+        {
+            new BuildMonitorOptions.IssuesOptions
+            {
+                Id = "azdo-fr-target",
+                Owner = "dotnet",
+                Name = "dnceng",
+                Labels = new[] { "Build Failed" }
+            }
+        };
+
+        var buildJson = CreateBuildJson();
+        var (controller, mockClient) = CreateController(options, buildJson);
+
+        var result = await controller.BuildComplete(CreateBuildEvent());
+
+        // Should create AzDO work item (not GitHub issue)
+        mockClient.Verify(m => m.CreateWorkItemAsync(
+            "internal", "DNCENG Task", It.IsAny<Dictionary<string, string>>(),
+            It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task BuildComplete_GitHubTarget_StillWorks()
+    {
+        // When only GitHub target exists, it should still work (no AzDoIssues configured)
+        var options = new BuildMonitorOptions
+        {
+            Monitor = new BuildMonitorOptions.AzurePipelinesOptions
+            {
+                Organization = "dnceng",
+                Builds = new[]
+                {
+                    new BuildMonitorOptions.AzurePipelinesOptions.BuildDescription
+                    {
+                        Project = "internal",
+                        DefinitionPath = "\\test\\test-pipeline",
+                        Branches = new[] { "main" },
+                        IssuesId = "github-target"
+                    }
+                }
+            },
+            Issues = new[]
+            {
+                new BuildMonitorOptions.IssuesOptions
+                {
+                    Id = "github-target",
+                    Owner = "dotnet",
+                    Name = "dnceng",
+                    Labels = new[] { "Build Failed" }
+                }
+            },
+            AzDoIssues = null
+        };
+
+        var buildJson = CreateBuildJson();
+        var (controller, mockClient) = CreateController(options, buildJson);
+
+        // Setup GitHub mocks
+        var mockGithubClient = new Mock<Octokit.IGitHubClient>();
+        var mockIssues = new Mock<Octokit.IIssuesClient>();
+        var mockComments = new Mock<Octokit.IIssueCommentsClient>();
+        mockGithubClient.SetupGet(m => m.Issue).Returns(mockIssues.Object);
+        mockIssues.SetupGet(m => m.Comment).Returns(mockComments.Object);
+        mockIssues.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Octokit.NewIssue>()))
+            .Returns(Task.FromResult(new Octokit.Issue()));
+
+        var mockFactory = new Mock<IGitHubApplicationClientFactory>();
+        mockFactory.Setup(m => m.CreateGitHubClientAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(Task.FromResult(mockGithubClient.Object));
+
+        var clientFactory = new SingleClientFactory<IAzureDevOpsClient>(mockClient.Object);
+        var optionsSnapshot = new Mock<IOptionsSnapshot<BuildMonitorOptions>>();
+        optionsSnapshot.Setup(o => o.Value).Returns(options);
+
+        var controllerWithGithub = new AzurePipelinesController(
+            mockFactory.Object,
+            clientFactory,
+            optionsSnapshot.Object,
+            NullLogger<AzurePipelinesController>.Instance);
+
+        var result = await controllerWithGithub.BuildComplete(CreateBuildEvent());
+
+        // Should NOT create AzDO work item
+        mockClient.Verify(m => m.CreateWorkItemAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(),
+            It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        // Should create GitHub issue
+        mockIssues.Verify(m => m.Create("dotnet", "dnceng", It.IsAny<Octokit.NewIssue>()), Times.Once);
+    }
+
+    [Test]
+    public async Task BuildComplete_NonMatchingBranch_NoWorkItemCreated()
+    {
+        var options = CreateOptionsWithAzDoTarget();
+        var buildJson = CreateBuildJson(branch: "refs/heads/release/8.0");
+        var (controller, mockClient) = CreateController(options, buildJson);
+
+        var result = await controller.BuildComplete(CreateBuildEvent());
+
+        mockClient.Verify(m => m.CreateWorkItemAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(),
+            It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
@@ -219,12 +219,6 @@
         "Labels": [ "Build Failed" ]
       },
       {
-        "Id": "dotnet-dnceng-first-responder",
-        "Owner": "dotnet",
-        "Name": "dnceng",
-        "Labels": [ "Build Failed", "Ops - First Responder" ]
-      },
-      {
         "Id": "dotnet-dnceng-ops",
         "Owner": "dotnet",
         "Name": "dnceng",
@@ -270,6 +264,16 @@
         "Owner": "dotnet",
         "Name": "arcade-services",
         "Labels": [ "Build Failed", "Ops - First Responder" ],
+        "UpdateExisting": true
+      }
+    ],
+    "AzDoIssues": [
+      {
+        "Id": "dotnet-dnceng-first-responder",
+        "Project": "internal",
+        "AreaPath": "internal\\.NET Engineering Services\\First Responders",
+        "WorkItemType": "DNCENG Task",
+        "Tags": [ "Ops - First Responder" ],
         "UpdateExisting": true
       }
     ]

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/AzurePipelinesController.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/AzurePipelinesController.cs
@@ -202,29 +202,170 @@ public class AzurePipelinesController : ControllerBase
             _logger.LogInformation("Fetching changes messages...");
             string changesMessage = await BuildChangesMessage(client, build);
 
-            BuildMonitorOptions.IssuesOptions repo = _options.Value.Issues.SingleOrDefault(i => string.Equals(monitor.IssuesId, i.Id, StringComparison.OrdinalIgnoreCase));
+            // Check for AzDO work item target first
+            BuildMonitorOptions.AzDoIssuesOptions azDoTarget = _options.Value.AzDoIssues?
+                .SingleOrDefault(i => string.Equals(monitor.IssuesId, i.Id, StringComparison.OrdinalIgnoreCase));
+
+            if (azDoTarget != null)
+            {
+                await CreateOrUpdateAzDoWorkItemAsync(client, build, monitor, azDoTarget, branchName, prettyTags, timelineMessage, changesMessage);
+                continue;
+            }
+
+            // Fall back to GitHub issues
+            BuildMonitorOptions.IssuesOptions repo = _options.Value.Issues?.SingleOrDefault(i => string.Equals(monitor.IssuesId, i.Id, StringComparison.OrdinalIgnoreCase));
 
             if (repo != null)
             {
-                IGitHubClient github = await _gitHubApplicationClientFactory.CreateGitHubClientAsync(repo.Owner, repo.Name);
+                await CreateOrUpdateGitHubIssueAsync(build, monitor, repo, branchName, prettyTags, timelineMessage, changesMessage);
+            }
+            else
+            {
+                _logger.LogWarning("Could not find a matching issues target for {issuesId}", monitor.IssuesId);
+            }
+        }
+    }
+
+    private async Task CreateOrUpdateAzDoWorkItemAsync(
+        IAzureDevOpsClient client,
+        Build build,
+        BuildMonitorOptions.AzurePipelinesOptions.BuildDescription monitor,
+        BuildMonitorOptions.AzDoIssuesOptions azDoTarget,
+        string branchName,
+        string prettyTags,
+        string timelineMessage,
+        string changesMessage)
+    {
+        DateTimeOffset? finishTime = DateTimeOffset.TryParse(build.FinishTime, out var parsedFinishTime) ? parsedFinishTime : (DateTimeOffset?)null;
+        DateTimeOffset? startTime = DateTimeOffset.TryParse(build.StartTime, out var parsedStartTime) ? parsedStartTime : (DateTimeOffset?)null;
+
+        string timeString = finishTime?.ToString("R") ?? "";
+        string durationString = (finishTime.HasValue && startTime.HasValue)
+            ? ((int)(finishTime.Value - startTime.Value).TotalMinutes) + " minutes"
+            : "";
+
+        string titlePrefix = $"Build failed: {build.Definition.Name}/{branchName} {prettyTags}".TrimEnd();
+
+        string description = $@"<p>Build <a href=""{build.Links.Web.Href}"">#{build.BuildNumber}</a> {build.Result}</p>
+<h2>{build.Project.Name} / {build.Definition.Name} {build.Result}</h2>
+<h3>Summary</h3>
+<ul>
+<li><strong>Finished</strong> - {timeString}</li>
+<li><strong>Duration</strong> - {durationString}</li>
+<li><strong>Requested for</strong> - {build.RequestedFor.DisplayName}</li>
+<li><strong>Reason</strong> - {build.Reason}</li>
+</ul>
+<h3>Details</h3>
+<pre>{timelineMessage}</pre>
+<h3>Changes</h3>
+<pre>{changesMessage}</pre>";
+
+        string tagString = BuildAzDoTagString(azDoTarget.Tags, monitor.Labels);
+
+        if (azDoTarget.UpdateExisting)
+        {
+            string wiql = $@"SELECT [System.Id] FROM WorkItems 
+                WHERE [System.TeamProject] = '{azDoTarget.Project}' 
+                AND [System.AreaPath] UNDER '{azDoTarget.AreaPath}' 
+                AND [System.Title] CONTAINS '{titlePrefix.Replace("'", "''")}'
+                AND [System.State] <> 'Done'
+                ORDER BY [System.CreatedDate] DESC";
+
+            WorkItem[] existing = await client.QueryWorkItemsAsync(azDoTarget.Project, wiql, CancellationToken.None);
+
+            if (existing != null && existing.Length > 0)
+            {
+                int workItemId = existing[0].Id;
+                _logger.LogInformation("Found existing AzDO work item {workItemId}, adding comment", workItemId);
+
+                string comment = $@"<p>Build <a href=""{build.Links.Web.Href}"">#{build.BuildNumber}</a> {build.Result} at {timeString}</p>
+<h3>Details</h3>
+<pre>{timelineMessage}</pre>
+<h3>Changes</h3>
+<pre>{changesMessage}</pre>";
+
+                await client.AddWorkItemCommentAsync(azDoTarget.Project, workItemId, comment, CancellationToken.None);
+                _logger.LogInformation("Added comment to AzDO work item {workItemId} for build failure", workItemId);
+                return;
+            }
+
+            _logger.LogInformation("No existing AzDO work item found for '{titlePrefix}', creating new one", titlePrefix);
+        }
+
+        var fields = new Dictionary<string, string>
+        {
+            ["System.Title"] = $"{titlePrefix} #{build.BuildNumber}",
+            ["System.Description"] = description,
+            ["System.State"] = "Backlog",
+        };
+
+        if (!string.IsNullOrEmpty(tagString))
+        {
+            fields["System.Tags"] = tagString;
+        }
+
+        if (!string.IsNullOrEmpty(monitor.Assignee))
+        {
+            fields["System.AssignedTo"] = monitor.Assignee;
+        }
+
+        WorkItem workItem = await client.CreateWorkItemAsync(
+            azDoTarget.Project,
+            azDoTarget.WorkItemType,
+            fields,
+            azDoTarget.AreaPath,
+            CancellationToken.None);
+
+        _logger.LogInformation("Created AzDO work item {project}/{workItemId} for build failure",
+            azDoTarget.Project, workItem?.Id);
+    }
+
+    private static string BuildAzDoTagString(string[] targetTags, string[] monitorLabels)
+    {
+        var allTags = new List<string>();
+        allTags.Add("Build Failed");
+
+        if (targetTags != null)
+        {
+            allTags.AddRange(targetTags);
+        }
+
+        if (monitorLabels != null)
+        {
+            allTags.AddRange(monitorLabels);
+        }
+
+        return string.Join("; ", allTags.Distinct(StringComparer.OrdinalIgnoreCase));
+    }
+
+    private async Task CreateOrUpdateGitHubIssueAsync(
+        Build build,
+        BuildMonitorOptions.AzurePipelinesOptions.BuildDescription monitor,
+        BuildMonitorOptions.IssuesOptions repo,
+        string branchName,
+        string prettyTags,
+        string timelineMessage,
+        string changesMessage)
+    {
+        IGitHubClient github = await _gitHubApplicationClientFactory.CreateGitHubClientAsync(repo.Owner, repo.Name);
                     
-                DateTimeOffset? finishTime = DateTimeOffset.TryParse(build.FinishTime, out var parsedFinishTime) ?parsedFinishTime: (DateTimeOffset?) null;
-                DateTimeOffset? startTime = DateTimeOffset.TryParse(build.StartTime, out var parsedStartTime) ? parsedStartTime:(DateTimeOffset?) null;
+        DateTimeOffset? finishTime = DateTimeOffset.TryParse(build.FinishTime, out var parsedFinishTime) ?parsedFinishTime: (DateTimeOffset?) null;
+        DateTimeOffset? startTime = DateTimeOffset.TryParse(build.StartTime, out var parsedStartTime) ? parsedStartTime:(DateTimeOffset?) null;
 
-                string timeString = "";
-                string durationString = "";
-                if (finishTime.HasValue)
-                {
-                    timeString = finishTime.Value.ToString("R");
-                    if (startTime.HasValue)
-                    {
-                        durationString = ((int) (finishTime.Value - startTime.Value).TotalMinutes) + " minutes";
-                    }
-                }
+        string timeString = "";
+        string durationString = "";
+        if (finishTime.HasValue)
+        {
+            timeString = finishTime.Value.ToString("R");
+            if (startTime.HasValue)
+            {
+                durationString = ((int) (finishTime.Value - startTime.Value).TotalMinutes) + " minutes";
+            }
+        }
 
-                string icon = build.Result == "failed" ? ":x:" : ":warning:";
+        string icon = build.Result == "failed" ? ":x:" : ":warning:";
 
-                string body = @$"Build [#{build.BuildNumber}]({build.Links.Web.Href}) {build.Result}
+        string body = @$"Build [#{build.BuildNumber}]({build.Links.Web.Href}) {build.Result}
 
 ## {icon} : {build.Project.Name} / {build.Definition.Name} {build.Result}
 
@@ -242,92 +383,73 @@ public class AzurePipelinesController : ControllerBase
 
 {changesMessage}
 ";
-                string issueTitlePrefix = $"Build failed: {build.Definition.Name}/{branchName} {prettyTags}";
+        string issueTitlePrefix = $"Build failed: {build.Definition.Name}/{branchName} {prettyTags}";
 
-                if (repo.UpdateExisting)
-                {
-                    // There is no way to get the username of our bot directly from the GithubApp with the C# api.
-                    // Issue opened in Octokit: https://github.com/octokit/octokit.net/issues/2335
-                    // We do, however, have access to the HtmlUrl, which ends with the name of the bot.
-                    // Additionally, when the bot opens issues, the username used ends with [bot], which isn't strictly
-                    // part of the name anywhere else. So, to get the correct creator name, get the HtmlUrl, grab
-                    // the bot's name from it, and append [bot] to that string.
-                    var githubAppClient = _gitHubApplicationClientFactory.CreateGitHubAppClient();
-                    string creator = (await githubAppClient.GitHubApps.GetCurrent()).HtmlUrl.Split("/").Last();
+        if (repo.UpdateExisting)
+        {
+            var githubAppClient = _gitHubApplicationClientFactory.CreateGitHubAppClient();
+            string creator = (await githubAppClient.GitHubApps.GetCurrent()).HtmlUrl.Split("/").Last();
 
-                    RepositoryIssueRequest issueRequest = new RepositoryIssueRequest {
-                        Creator = $"{creator}[bot]",
-                        State = ItemStateFilter.Open,
-                        SortProperty = IssueSort.Created,
-                        SortDirection = SortDirection.Descending
-                    };
+            RepositoryIssueRequest issueRequest = new RepositoryIssueRequest {
+                Creator = $"{creator}[bot]",
+                State = ItemStateFilter.Open,
+                SortProperty = IssueSort.Created,
+                SortDirection = SortDirection.Descending
+            };
 
-                    foreach (string label in repo.Labels.OrEmpty())
-                    {
-                        issueRequest.Labels.Add(label);
-                    }
+            foreach (string label in repo.Labels.OrEmpty())
+            {
+                issueRequest.Labels.Add(label);
+            }
 
-                    foreach (string label in monitor.Labels.OrEmpty())
-                    {
-                        issueRequest.Labels.Add(label);
-                    }
+            foreach (string label in monitor.Labels.OrEmpty())
+            {
+                issueRequest.Labels.Add(label);
+            }
 
-                    List<Issue> matchingIssues = (await github.Issue.GetAllForRepository(repo.Owner, repo.Name, issueRequest)).ToList();
-                    Issue matchingIssue = matchingIssues.FirstOrDefault(i => i.Title.StartsWith(issueTitlePrefix));
+            List<Issue> matchingIssues = (await github.Issue.GetAllForRepository(repo.Owner, repo.Name, issueRequest)).ToList();
+            Issue matchingIssue = matchingIssues.FirstOrDefault(i => i.Title.StartsWith(issueTitlePrefix));
 
-                    if (matchingIssue != null)
-                    {
-                        _logger.LogInformation("Found matching issue {issueNumber} in {owner}/{repo}. Will attempt to add a new comment.", matchingIssue.Number, repo.Owner, repo.Name);
-                        // Add a new comment to the issue with the body
-                        IssueComment newComment = await github.Issue.Comment.Create(repo.Owner, repo.Name, matchingIssue.Number, body);
-                        _logger.LogInformation("Logged comment in {owner}/{repo}#{issueNumber} for build failure", repo.Owner, repo.Name, matchingIssue.Number);
+            if (matchingIssue != null)
+            {
+                _logger.LogInformation("Found matching issue {issueNumber} in {owner}/{repo}. Will attempt to add a new comment.", matchingIssue.Number, repo.Owner, repo.Name);
+                IssueComment newComment = await github.Issue.Comment.Create(repo.Owner, repo.Name, matchingIssue.Number, body);
+                _logger.LogInformation("Logged comment in {owner}/{repo}#{issueNumber} for build failure", repo.Owner, repo.Name, matchingIssue.Number);
 
-                        return;
-                    }
-                    else
-                    {
-                        _logger.LogInformation("Matching issues for {issueTitlePrefix} not found. Creating a new issue.", issueTitlePrefix);
-                    }
-                }
-
-                // Create new issue if repo.UpdateExisting is false or there were no matching issues
-                var newIssue =
-                    new NewIssue($"{issueTitlePrefix} #{build.BuildNumber}")
-                    {
-                        Body = body,
-                    };
-
-                if (!string.IsNullOrEmpty(monitor.Assignee))
-                {
-                    newIssue.Assignees.Add(monitor.Assignee);
-                }
-                    
-                foreach (string label in repo.Labels.OrEmpty())
-                {
-                    newIssue.Labels.Add(label);
-                }
-
-                foreach (string label in monitor.Labels.OrEmpty())
-                {
-                    newIssue.Labels.Add(label);
-                }
-
-                /*
-                 * We are sometimes seeing an OctoKit.ApiValidationException in the dotneteng-status app insights logs when creating issues.
-                 * This is potentially related to https://github.com/octokit/octokit.net/issues/612.
-                 * Adding logging here to help us track down the issue.
-                 */
-                _logger.LogInformation("Creating issue {owner}/{repo} with title '{issueTitle}' in the {milestone} milestone.", repo.Owner, repo.Name, newIssue.Title, newIssue.Milestone);
-
-                Issue issue = await github.Issue.Create(repo.Owner, repo.Name, newIssue);
-
-                _logger.LogInformation("Logged issue {owner}/{repo}#{issueNumber} for build failure", repo.Owner, repo.Name, issue.Number);
+                return;
             }
             else
             {
-                _logger.LogWarning("Could not find a matching repo for {issuesId}", monitor.IssuesId);
+                _logger.LogInformation("Matching issues for {issueTitlePrefix} not found. Creating a new issue.", issueTitlePrefix);
             }
         }
+
+        var newIssue =
+            new NewIssue($"{issueTitlePrefix} #{build.BuildNumber}")
+            {
+                Body = body,
+            };
+
+        if (!string.IsNullOrEmpty(monitor.Assignee))
+        {
+            newIssue.Assignees.Add(monitor.Assignee);
+        }
+                    
+        foreach (string label in repo.Labels.OrEmpty())
+        {
+            newIssue.Labels.Add(label);
+        }
+
+        foreach (string label in monitor.Labels.OrEmpty())
+        {
+            newIssue.Labels.Add(label);
+        }
+
+        _logger.LogInformation("Creating issue {owner}/{repo} with title '{issueTitle}' in the {milestone} milestone.", repo.Owner, repo.Name, newIssue.Title, newIssue.Milestone);
+
+        Issue issue = await github.Issue.Create(repo.Owner, repo.Name, newIssue);
+
+        _logger.LogInformation("Logged issue {owner}/{repo}#{issueNumber} for build failure", repo.Owner, repo.Name, issue.Number);
     }
 
     private async Task<string> BuildChangesMessage(IAzureDevOpsClient client, Build build)

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Options/BuildMonitorOptions.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Options/BuildMonitorOptions.cs
@@ -8,6 +8,7 @@ public class BuildMonitorOptions
 {
     public AzurePipelinesOptions Monitor { get; set; }
     public IssuesOptions[] Issues { get; set; }
+    public AzDoIssuesOptions[] AzDoIssues { get; set; }
 
     public class AzurePipelinesOptions
     {
@@ -32,6 +33,16 @@ public class BuildMonitorOptions
         public string Owner { get; set; }
         public string Name { get; set; }
         public string[] Labels { get; set; }
+        public bool UpdateExisting { get; set; }
+    }
+
+    public class AzDoIssuesOptions
+    {
+        public string Id { get; set; }
+        public string Project { get; set; }
+        public string AreaPath { get; set; }
+        public string WorkItemType { get; set; } = "DNCENG Task";
+        public string[] Tags { get; set; }
         public bool UpdateExisting { get; set; }
     }
 }


### PR DESCRIPTION
## Summary

Updates the Build Monitor to create Azure DevOps work items instead of GitHub issues for dnceng first-responder pipelines.

## Changes

- **BuildMonitorOptions.cs**: Added AzDoIssuesOptions class with Project, AreaPath, WorkItemType, Tags, and UpdateExisting properties. Added AzDoIssues array to BuildMonitorOptions.
- **AzurePipelinesController.cs**: Refactored ProcessBuildNotificationsAsync to check AzDO targets first, then fall back to GitHub. Added CreateOrUpdateAzDoWorkItemAsync for work item creation/update logic. Extracted CreateOrUpdateGitHubIssueAsync for cleaner separation.
- **settings.json**: Migrated \dotnet-dnceng-first-responder\ from GitHub issues (dotnet/dnceng) to AzDO work items (internal/.NET Engineering Services/First Responders area path).
- **AzurePipelinesControllerAzDoTests.cs**: 6 new tests covering AzDO work item creation, update-existing with comment, fallback to GitHub, priority over GitHub when both configured, and branch filtering.

## Motivation

Resolves [AB#8006](https://dev.azure.com/dnceng/internal/_workitems/edit/8006) - Build Monitor issues for dnceng should open in AzDO instead of GitHub.

This aligns with the team's practice of tracking all operational work in AzDO rather than GitHub issues.