### PR TITLE
[PAT Migration] Remove devdiv/engineering PAT from secret manifest (WI 10126)

### DIFF
--- a/.vault-config/service-connections-dnceng.yaml
+++ b/.vault-config/service-connections-dnceng.yaml
@@ -38,19 +38,6 @@ secrets:
           organizations: devdiv
           scopes: packaging_write
 
-  devdiv/engineering:
-    type: azure-devops-service-endpoint
-    parameters:
-      authorization:
-        type: azure-devops-access-token
-        parameters:
-          domainAccountName: dn-bot
-          domainAccountSecret:
-            location: helixkv
-            name: dn-bot-account-redmond
-          organizations: devdiv
-          scopes: packaging
-
   azure-public/vssdk:
     type: azure-devops-service-endpoint
     parameters:


### PR DESCRIPTION
Remove the devdiv/engineering PAT entry from the secret manifest. This SC has been migrated to WIF (devdiv-engineering-feed-r-wif) and all consuming pipelines (roslyn, VMR, razor) have been using the new SC successfully since May 15.

Per policy: fully delete PAT entries from the secret manifest, do not deprecate to 	ype: text.

## Post-merge steps

- [ ] Delete old devdiv/engineering PAT-based SC (ID: 9a5e0e6-1e1c-49b4-b8ca-bf80f667dfa6) from dnceng/internal
- [ ] Move WI 10126 to Done

Resolves: https://dev.azure.com/dnceng/internal/_workitems/edit/10126