### PR TITLE
[PAT Migration] Remove dotnet-eng PAT from secret manifest (WI 10114)

### DIFF
--- a/.vault-config/service-connections-devdiv.yaml
+++ b/.vault-config/service-connections-devdiv.yaml
@@ -12,19 +12,6 @@ references:
       name: helixkv
 
 secrets:
-  dotnet-eng:
-    type: azure-devops-service-endpoint
-    parameters:
-      authorization:
-        type: azure-devops-access-token
-        parameters:
-          domainAccountName: dn-bot
-          domainAccountSecret:
-            location: helixkv
-            name: dn-bot-account-redmond
-          organizations: dnceng
-          scopes: packaging_write
-
   dnceng-test-tools-feed:
     type: azure-devops-service-endpoint
     parameters:


### PR DESCRIPTION
## Summary

Removes the `dotnet-eng` PAT entry from `.vault-config/service-connections-devdiv.yaml`, stopping the useless PAT rotation for this service connection.

## Background

The `dotnet-eng` SC (ID: `b41c24b4-0dbc-49a3-8e25-e76614489d9a`) in devdiv/DevDiv points to the `dnceng/public/_packaging/dotnet-eng` NuGet feed. It's still Token-based, but **all consuming pipelines already override the PAT at runtime with an Entra token**:

- **macios-adr** and **macios-mlaunch** both use an `AzureCLI@2` step (`dotnet-eng-mi` managed identity SC) to call `##vso[task.setendpoint]` and replace the SC's apitoken before the NuGet push runs.
- The override and the push have identical conditions -- the push never runs without the override.
- No other pipeline references this SC in YAML (5 other pipelines are authorized-only, not consuming).

The PAT has been effectively dead since Nov 2024 when the Xamarin team added the MI override. Secret-manager has been rotating a token that is always discarded.

## Post-merge steps

- [ ] Monitor next `macios-adr` and `macios-mlaunch` builds on main (should be unaffected -- they use MI)
- [ ] Move WI 10114 to Done

Resolves: https://dev.azure.com/dnceng/internal/_workitems/edit/10114

AB#10114