### PR TITLE
[PAT Migration] Remove unused dnceng-dotnet10 SC from secret manifest (WI 10116)

### DIFF
--- a/.vault-config/service-connections-devdiv.yaml
+++ b/.vault-config/service-connections-devdiv.yaml
@@ -38,19 +38,6 @@ secrets:
           organizations: dnceng
           scopes: packaging_write
 
-  dnceng-dotnet10:
-    type: azure-devops-service-endpoint
-    parameters:
-      authorization:
-        type: azure-devops-access-token
-        parameters:
-          domainAccountName: dn-bot
-          domainAccountSecret:
-            location: helixkv
-            name: dn-bot-account-redmond
-          organizations: dnceng
-          scopes: packaging_write
-
   dnceng-dotnet9:
     type: azure-devops-service-endpoint
     parameters:


### PR DESCRIPTION
## Summary

Removes the \dnceng-dotnet10\ PAT entry from \.vault-config/service-connections-devdiv.yaml\.

## Evidence of Non-Use

- **Zero authorized pipelines** — the SC has no pipeline permissions at all
- SC ID: \cec30ebb-8b52-460e-8684-a572243a637a\ in devdiv/DevDiv
- Points to: \https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json\
- Code search (AzDO + GitHub): no YAML references to \dnceng-dotnet10\ found anywhere

Secret-manager has been rotating a PAT that nothing consumes. This PR stops the useless rotation.

## Post-merge steps

- [ ] Delete the SC itself from devdiv/DevDiv (ID: \cec30ebb-8b52-460e-8684-a572243a637a\)
- [ ] Move WI 10116 to Done

Resolves: https://dev.azure.com/dnceng/internal/_workitems/edit/10116