### PR TITLE
Remove dnceng-dotnet8 SC from secret manifest (WI 10118)

### DIFF
--- a/.vault-config/service-connections-devdiv.yaml
+++ b/.vault-config/service-connections-devdiv.yaml
@@ -64,19 +64,6 @@ secrets:
           organizations: dnceng
           scopes: packaging_write
 
-  dnceng-dotnet8:
-    type: azure-devops-service-endpoint
-    parameters:
-      authorization:
-        type: azure-devops-access-token
-        parameters:
-          domainAccountName: dn-bot
-          domainAccountSecret:
-            location: helixkv
-            name: dn-bot-account-redmond
-          organizations: dnceng
-          scopes: packaging_write
-
   dnceng-dotnet8-workloads:
     type: azure-devops-service-endpoint
     parameters:


### PR DESCRIPTION
## Summary

Removes the \dnceng-dotnet8\ service connection entry from \.vault-config/service-connections-devdiv.yaml\.

## Justification

This SC has **zero active consumers**:
- \dotnet/android\ switched its \DotNetFeedCredential\ to \dnceng-dotnet9\
- No code in any DevDiv repo or GitHub repo references \dnceng-dotnet8\
- The 3 authorized pipelines (Xamarin.Android #11410, xamarin-macios-ci #14411, xamarin.megapipeline #17671) have permission but do not reference it in YAML

The SC authorization was likely from when \dotnet/android\ used dotnet8 feed; they have since moved to dotnet9.

## Risk

None — no pipeline consumes this credential. Removing it stops unnecessary PAT rotation.

Resolves: https://dev.azure.com/dnceng/internal/_workitems/edit/10118