### PR TITLE
Remove dnceng-dotnet9 SC from secret manifest (WI 10117)

### DIFF
--- a/.vault-config/service-connections-devdiv.yaml
+++ b/.vault-config/service-connections-devdiv.yaml
@@ -51,19 +51,6 @@ secrets:
           organizations: dnceng
           scopes: packaging_write
 
-  dnceng-dotnet9:
-    type: azure-devops-service-endpoint
-    parameters:
-      authorization:
-        type: azure-devops-access-token
-        parameters:
-          domainAccountName: dn-bot
-          domainAccountSecret:
-            location: helixkv
-            name: dn-bot-account-redmond
-          organizations: dnceng
-          scopes: packaging_write
-
   dnceng-dotnet8:
     type: azure-devops-service-endpoint
     parameters:


### PR DESCRIPTION
## Summary

Removes the \dnceng-dotnet9\ service connection entry from \.vault-config/service-connections-devdiv.yaml\.

## Justification

This SC has **no active consumers** — the variable definition in \dotnet/android\ is dead code:

1. **Variable never consumed**: \DotNetFeedCredential: dnceng-dotnet9\ is defined in \zure-pipelines.yaml\ but \\\ is never expanded anywhere in the repo
2. **NuGetAuthenticate doesn't use it**: The \NuGetAuthenticate@1\ tasks specify \orceReinstallCredentialProvider: true\ but do NOT pass \
uGetServiceConnections\, so the SC is unused
3. **Feeds have moved on**: \NuGet.config\ now references \dotnet11\ feeds, not \dotnet9\
4. **Publishing uses Maestro**: Packages are pushed to BAR via \AzureCLI@2\ + Maestro, not direct NuGet push to the dotnet9 feed
5. **dotnet/macios**: Authorized-only (no code reference)

## Risk

None — no pipeline consumes this credential. Removing it stops unnecessary PAT rotation.

## Follow-up suggestion

The \dotnet/android\ team should clean up the dead \DotNetFeedCredential\ variable definition from their pipeline YAML.

Resolves: https://dev.azure.com/dnceng/internal/_workitems/edit/10117