### PR TITLE
Remove unused security-partner feed SCs from manifest (WIs 10132, 10133)

### DIFF
--- a/.vault-config/service-connections-dnceng.yaml
+++ b/.vault-config/service-connections-dnceng.yaml
@@ -89,29 +89,3 @@ secrets:
             name: dn-bot-account-redmond
           organizations: dnceng
           scopes: packaging_write
-
-  dotnet-security-partners-enterprise-distro-partners-dotnet feed:
-    type: azure-devops-service-endpoint
-    parameters:
-      authorization:
-        type: azure-devops-access-token
-        parameters:
-          domainAccountName: dn-bot
-          domainAccountSecret:
-            location: helixkv
-            name: dn-bot-account-redmond
-          organizations: dotnet-security-partners
-          scopes: packaging_write
-
-  dotnet-security-partners-servicing-partners-dotnet feed:
-    type: azure-devops-service-endpoint
-    parameters:
-      authorization:
-        type: azure-devops-access-token
-        parameters:
-          domainAccountName: dn-bot
-          domainAccountSecret:
-            location: helixkv
-            name: dn-bot-account-redmond
-          organizations: dotnet-security-partners
-          scopes: packaging_write


### PR DESCRIPTION
## Summary

Removes two unused \xternalnugetfeed\ service connections from the secret-manager manifest:

- \dotnet-security-partners-enterprise-distro-partners-dotnet feed\ (SC ID: \