### PR TITLE
Fix graph color contrast to meet MAS 1.4.11 accessibility requirements and fix dnceng folder listing

### DIFF
--- a/src/Monitoring/Monitoring.DncEng/dashboard/general/home.dashboard.json
+++ b/src/Monitoring/Monitoring.DncEng/dashboard/general/home.dashboard.json
@@ -48,7 +48,7 @@
       },
       "id": 6,
       "options": {
-        "folderId": "[parameter(dnceng-folderid)]",
+        "folderUID": "dnceng",
         "maxItems": 10,
         "query": "",
         "showHeadings": false,
@@ -358,7 +358,7 @@
               "mode": "none"
             },
             "thresholdsStyle": {
-              "mode": "line+area"
+              "mode": "line"
             }
           },
           "mappings": [],


### PR DESCRIPTION

 - Change thresholdsStyle from "line+area" to "line" on the Work Items Waiting Time (Test Queues) panel to remove the red background fill
 - Replace numeric folderId parameter with folderUID "dnceng" on the dnceng dashlist panel so it correctly lists dashboards from the dnceng dashboard folder
 
 work item: https://dev.azure.com/dnceng/internal/_workitems/edit/10195