### PR TITLE
Remove DotNet-Symbol-Server-Pats variable group reference

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,9 +76,7 @@ extends:
                   targetPath: $(Build.SourcesDirectory)\artifacts\bin\AzureDevOpsClient.PostDeploymentTests\$(_BuildConfig)\net8.0
                   artifactName: AzureDevOpsClient.PostDeploymentTests
             variables:
-            # DotNet-Symbol-Server-Pats provides: microsoft-symbol-server-pat, symweb-symbol-server-pat
             # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
-            - group: DotNet-Symbol-Server-Pats
             - group: Publish-Build-Assets
             - _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
             - _BuildConfig: Release
@@ -92,8 +90,6 @@ extends:
                 /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
                 /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
                 /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
-                /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-                /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
                 /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
           
             steps:


### PR DESCRIPTION
## Summary

The `DotNet-Symbol-Server-Pats` variable group no longer exists or is not authorized for the `dotnet-dnceng-ci` pipeline (definition 1254), causing build failures:

> Variable group DotNet-Symbol-Server-Pats could not be found. The variable group does not exist or has not been authorized for use.

**Failed build:** https://dev.azure.com/dnceng/internal/_build/results?buildId=2986650&view=results

## Changes

- Removed the `DotNet-Symbol-Server-Pats` variable group reference
- Removed the `/p:DotNetSymbolServerTokenMsdl` and `/p:DotNetSymbolServerTokenSymWeb` MSBuild arguments that consumed variables from that group

These MSBuild properties are no longer consumed by current Arcade build infrastructure — symbol publishing is handled by the post-build template using managed identity.

## Risk

Low — the variables being removed are confirmed unused by current Arcade templates (zero references in `dotnet/arcade` eng/common).