### PR TITLE
Remove azure-public/vs-impl from secret-manager manifest (WIF migrated)

### DIFF
--- a/.vault-config/service-connections-dnceng.yaml
+++ b/.vault-config/service-connections-dnceng.yaml
@@ -51,19 +51,6 @@ secrets:
           organizations: azure-public
           scopes: packaging_write
 
-  azure-public/vs-impl:
-    type: azure-devops-service-endpoint
-    parameters:
-      authorization:
-        type: azure-devops-access-token
-        parameters:
-          domainAccountName: dn-bot
-          domainAccountSecret:
-            location: helixkv
-            name: dn-bot-account-redmond
-          organizations: azure-public
-          scopes: packaging_write
-
   dotnet-security-partners-dotnet-dotnet feed:
     type: azure-devops-service-endpoint
     parameters:


### PR DESCRIPTION
## Summary

Remove the `azure-public/vs-impl` PAT-backed service connection entry from the secret-manager manifest. This PAT rotation is no longer needed because:

1. **dotnet-project-system** and **vs-solutionpersistence** (in dotnet-dotnet) have migrated to WIF auth via the `WIFtoPATauth.yml` shim using the `azure-public/vside package push` SC.
2. **dotnet-winforms** (`release/shgu/packagepublish` branch) — Shyam Gupta confirmed this branch is no longer in use.

## What this does NOT do

- Does **not** delete the `azure-public/vs-impl` service connection from AzDO. The SC must remain because it's still referenced by name in `publishFeedCredentials` in YAML — the WIF shim overrides its token at runtime.

## Related

- Work item: AB#10129
- WIF SC: `azure-public/vside package push`