### PR TITLE
Fix AlertHookController AzDO auth by specifying user-assigned MI

### DIFF
--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Production.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Production.json
@@ -40,7 +40,8 @@
       "ManagedIdentityClientId": "b73bcdd4-aba9-40a7-af0c-f95b8eb5ab62"
     },
     "dnceng": {
-      "UseManagedIdentity": true
+      "UseManagedIdentity": true,
+      "ManagedIdentityClientId": "b73bcdd4-aba9-40a7-af0c-f95b8eb5ab62"
     }
   }
 }

--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Staging.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Staging.json
@@ -41,7 +41,8 @@
       "ManagedIdentityClientId": "8cd89985-08e4-4baa-86f1-76ee58b6b393"
     },
     "dnceng": {
-      "UseManagedIdentity": true
+      "UseManagedIdentity": true,
+      "ManagedIdentityClientId": "8cd89985-08e4-4baa-86f1-76ee58b6b393"
     }
   }
 }


### PR DESCRIPTION
## Problem

The Grafana AlertHook controller (AlertHookController) calls _azureDevOpsClientFactory.GetClient("dnceng") to create AzDO work items. The `dnceng` client config in settings.Production.json had:

```json
"dnceng": {
  "UseManagedIdentity": true
}
```

Without an explicit ManagedIdentityClientId, the AzureDevOpsClient falls back to the **system-assigned MI** (principalId 18f89124-4dfc-4aa1-b9ef-93650f6dfad0), which doesn't have permissions in the dnceng AzDO org. This caused HTTP 500 responses with inner `401 (Unauthorized)` from AzDO.

## Fix

Add the ManagedIdentityClientId for both Production and Staging configs, matching the same user-assigned MI already used by the `build-monitor/dnceng` client (which works correctly).

## Evidence

App Insights shows the 401 coming from the outbound AzDO call:
```
System.Net.Http.HttpRequestException: Response status code does not indicate success: 401 (Unauthorized)
  at Microsoft.DotNet.Internal.AzureDevOps.AzureDevOpsClient.PostJsonResult (AzureDevOpsClient.cs:531)
```

## Validation

After deploy, trigger a test Grafana alert and verify the AlertHook successfully creates an AzDO work item (HTTP 200 instead of 500).

Fixes: AB#8579