### PR TITLE
Update image from 1es-windows-2019 to 1es-windows-2022

### DIFF
--- a/eng/deploy-managed-grafana.yml
+++ b/eng/deploy-managed-grafana.yml
@@ -17,7 +17,7 @@ stages:
   displayName: 'Deploy Grafana Infrastructure and Dashboards'
   pool:
     name: NetCore1ESPool-Internal-NoMSI
-    demands: ImageOverride -equals 1es-windows-2019
+    demands: ImageOverride -equals 1es-windows-2022
   dependsOn:
   - predeploy
   - approval


### PR DESCRIPTION
Updates the image override in `eng/deploy-managed-grafana.yml` from `1es-windows-2019` to `1es-windows-2022`.