### PR TITLE
[Rollout] Production rollout, 2026-07-01

### DIFF
--- a/eng/deploy-managed-grafana.yml
+++ b/eng/deploy-managed-grafana.yml
@@ -17,7 +17,7 @@ stages:
   displayName: 'Deploy Grafana Infrastructure and Dashboards'
   pool:
     name: NetCore1ESPool-Internal-NoMSI
-    demands: ImageOverride -equals 1es-windows-2019
+    demands: ImageOverride -equals 1es-windows-2022
   dependsOn:
   - predeploy
   - approval


### PR DESCRIPTION
## Rollout for dotnet-dnceng

**Deployment date:** 2026-07-01
**Rollout branch:** `rollout/2026-07-01` cut from `custom` @ `bd64de5` (custom = mainHead — full rollout)
**Work item:** [#11387](https://dnceng.visualstudio.com/internal/_workitems/edit/11387)
**Merge strategy:** Merge commit (do NOT squash, do NOT rebase)

### Included commits

1. `bd64de5` Merged PR 6623: Update image from 1es-windows-2019 to 1es-windows-2022 — Epsitha

### Changes included

#### Feature changes/additions
_None_

#### Bug fixes
_None_

#### Internal Infrastructure Improvements
- PR #6623 - Update image from 1es-windows-2019 to 1es-windows-2022

### Reviewers requested
- @epananth
- @dotnet/dnceng
