### PR TITLE
Remove azure-public/vssdk and azure-public/vs-impl SC manifest entries

### DIFF
--- a/.vault-config/service-connections-dnceng.yaml
+++ b/.vault-config/service-connections-dnceng.yaml
@@ -38,32 +38,6 @@ secrets:
           organizations: devdiv
           scopes: packaging_write
 
-  azure-public/vssdk:
-    type: azure-devops-service-endpoint
-    parameters:
-      authorization:
-        type: azure-devops-access-token
-        parameters:
-          domainAccountName: dn-bot
-          domainAccountSecret:
-            location: helixkv
-            name: dn-bot-account-redmond
-          organizations: azure-public
-          scopes: packaging_write
-
-  azure-public/vs-impl:
-    type: azure-devops-service-endpoint
-    parameters:
-      authorization:
-        type: azure-devops-access-token
-        parameters:
-          domainAccountName: dn-bot
-          domainAccountSecret:
-            location: helixkv
-            name: dn-bot-account-redmond
-          organizations: azure-public
-          scopes: packaging_write
-
   dotnet-security-partners-dotnet-dotnet feed:
     type: azure-devops-service-endpoint
     parameters:


### PR DESCRIPTION
## Summary

Remove the PAT-backed service connection manifest entries for zure-public/vssdk and zure-public/vs-impl.

## Rationale

Both feeds (ssdk and s-impl) in the zure-public/vside organization are **publicly readable**. No authentication is required for NuGet restore operations against these feeds. The PAT-backed service connections were unnecessary overhead.

## Related PRs
- dotnet/roslyn#84427 — removes NuGetAuthenticate steps referencing these SCs
- dotnet/interactive-window#289 — removes NuGetAuthenticate step referencing azure-public/vssdk

## Work Items
- WI 10128 (azure-public/vssdk)
- WI 10129 (azure-public/vs-impl)