### PR TITLE
Remove DevDiv - VS package feed PAT SC from vault config (WI 10125)

### DIFF
--- a/.vault-config/service-connections-dnceng.yaml
+++ b/.vault-config/service-connections-dnceng.yaml
@@ -25,18 +25,6 @@ secrets:
           organizations: devdiv
           scopes: packaging_write
 
-  DevDiv - VS package feed:
-    type: azure-devops-service-endpoint
-    parameters:
-      authorization:
-        type: azure-devops-access-token
-        parameters:
-          domainAccountName: dn-bot
-          domainAccountSecret:
-            location: helixkv
-            name: dn-bot-account-redmond
-          organizations: devdiv
-          scopes: packaging_write
 
   dotnet-security-partners-dotnet-dotnet feed:
     type: azure-devops-service-endpoint


### PR DESCRIPTION
Cleanup for WI 10125. Migrated to WIF SC. Old SC deleted from AzDO. Post-merge build 3018885 confirmed working.