### PR TITLE
Remove dotnet-security-partners feed

### DIFF
--- a/.vault-config/service-connections-dnceng.yaml
+++ b/.vault-config/service-connections-dnceng.yaml
@@ -38,19 +38,6 @@ secrets:
           organizations: devdiv
           scopes: packaging_write
 
-  dotnet-security-partners-dotnet-dotnet feed:
-    type: azure-devops-service-endpoint
-    parameters:
-      authorization:
-        type: azure-devops-access-token
-        parameters:
-          domainAccountName: dn-bot
-          domainAccountSecret:
-            location: helixkv
-            name: dn-bot-account-redmond
-          organizations: dotnet-security-partners
-          scopes: packaging_write
-
   dotnet-sb-validation feed:
     type: azure-devops-service-endpoint
     parameters:


### PR DESCRIPTION
Follow-up to AB#10130, remove no longer needed PAT. 