### PR TITLE
Fix non-descriptive home page title

### DIFF
--- a/src/DotNet.Status.Web/DotNet.Status.Web/Pages/Index.cshtml
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Pages/Index.cshtml
@@ -2,7 +2,7 @@
 @using System.Security.Claims
 @using System.Reflection
 @{
-    ViewData["Title"] = "Home page";
+    ViewData["Title"] = ".NET Engineering Status - Home";
     var appVersion = Assembly.GetEntryAssembly()
                         ?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
                         ?.InformationalVersion?.ToString() ?? "Unknown";


### PR DESCRIPTION
Update the page title in `Index.cshtml` from the generic "Home page" to ".Net Engneering Status - Home" so screen readers and browser tabs clearly identify the application and page context.

WorkItem: https://dev.azure.com/dnceng/internal/_workitems/edit/11150