### PR TITLE
Make dotnet-eng-status deployment notifications best-effort (fix intermittent 500)

### DIFF
--- a/.vault-config/dotneteng-status-local.yaml
+++ b/.vault-config/dotneteng-status-local.yaml
@@ -19,11 +19,6 @@ secrets:
       hasWebhookSecret: true
       hasOAuthSecret: true
 
-  grafana-api-token:
-    type: azure-managed-grafana-api-key
-    parameters:
-      environment: dotnet-eng-grafana-staging.westus2.cloudapp.azure.com
-
   # Shared secret for Grafana webhook contact point Basic Auth
   grafana-webhook-secret:
     type: text

--- a/.vault-config/dotneteng-status-prod.yaml
+++ b/.vault-config/dotneteng-status-prod.yaml
@@ -19,12 +19,6 @@ keys:
 importSecretsFrom: shared/dotneteng-status-secrets.yaml
 
 secrets:
-  # Grafana API key with admin privileges
-  grafana-api-token:
-    type: azure-managed-grafana-api-key
-    parameters:
-      environment: dotnet-eng-grafana.westus2.cloudapp.azure.com
-
   # Shared secret for Grafana webhook contact point Basic Auth
   grafana-webhook-secret:
     type: text

--- a/.vault-config/dotneteng-status-staging.yaml
+++ b/.vault-config/dotneteng-status-staging.yaml
@@ -19,12 +19,6 @@ keys:
 importSecretsFrom: shared/dotneteng-status-secrets.yaml
 
 secrets:
-  # Grafana API key with admin privileges
-  grafana-api-token:
-    type: azure-managed-grafana-api-key
-    parameters:
-      environment: dotnet-eng-grafana-staging.westus2.cloudapp.azure.com
-
   # Shared secret for Grafana webhook contact point Basic Auth
   grafana-webhook-secret:
     type: text

--- a/src/DotNet.Status.Web/DotNet.Status.Web.Tests/AnnotationsControllerTests.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web.Tests/AnnotationsControllerTests.cs
@@ -122,7 +122,7 @@ public class AnnotationsControllerTests
                 services.AddControllers()
                     .AddApplicationPart(typeof(AnnotationsController).Assembly);
 
-                services.Configure<GrafanaOptions>(options =>
+                services.Configure<DeploymentTableOptions>(options =>
                 {
                     options.TableUri = "https://127.0.0.1:10002/devstoreaccount1/deployments";
                 });

--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Development.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Development.json
@@ -49,7 +49,7 @@
     "StorageAccountConnectionString": "",
     "KeyIdentifier": ""
   },
-  "Grafana": {
+  "Deployments": {
     "TableUri": ""
   },
   "Kusto": {

--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Production.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Production.json
@@ -23,8 +23,7 @@
   "AzureTableTokenStore": {
     "TableUri": "https://dotnetengstatusprod.table.core.windows.net"
   },
-  "Grafana": {
-    "BaseUrl": "https://dotnet-eng-grafana.westus2.cloudapp.azure.com",
+  "Deployments": {
     "TableUri": "https://dotnetengstatusprod.table.core.windows.net"
   },
   "Kusto": {

--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Staging.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Staging.json
@@ -25,7 +25,7 @@
   "AzureTableTokenStore": {
     "TableUri": "https://dotnetengstatusstaging.table.core.windows.net"
   },
-  "Grafana": {
+  "Deployments": {
     "TableUri": "https://dotnetengstatusstaging.table.core.windows.net"
   },
   "Kusto": {

--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
@@ -300,10 +300,10 @@
   "AzureTableTokenStore": {
     "TableName": "tokens"
   },
+  "Deployments": {
+    "TableName": "deployments"
+  },
   "Grafana": {
-    "BaseUrl": "https://dotnet-eng-grafana-staging.westus2.cloudapp.azure.com",
-    "ApiToken": "[vault(grafana-api-token)]",
-    "TableName": "deployments",
     "WebhookSecret": "[vault(grafana-webhook-secret)]"
   },
   "WebHooks": {

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/AnnotationsController.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/AnnotationsController.cs
@@ -28,12 +28,12 @@ public class AnnotationsController : ControllerBase
 {
     private const int _maximumServerCount = 10; // Safety limit on query complexity
     private readonly ILogger<AnnotationsController> _logger;
-    private readonly IOptionsMonitor<GrafanaOptions> _options;
+    private readonly IOptionsMonitor<DeploymentTableOptions> _options;
     private readonly IHostEnvironment _env;
 
     public AnnotationsController(
         ILogger<AnnotationsController> logger,
-        IOptionsMonitor<GrafanaOptions> options,
+        IOptionsMonitor<DeploymentTableOptions> options,
         IHostEnvironment env)
     {
         _logger = logger;

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/DeploymentController.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/DeploymentController.cs
@@ -4,26 +4,15 @@
 
 using Azure;
 using System;
-using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
-using System.IO;
-using System.Net;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Azure.Data.Tables;
 using DotNet.Status.Web.Options;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.DotNet.Services.Utility;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using StatusWebAnnotationEntity = DotNet.Status.Web.Models.AnnotationEntity;
-using Microsoft.WindowsAzure.Storage.Table;
 using Azure.Identity;
 
 namespace DotNet.Status.Web.Controllers;
@@ -33,17 +22,14 @@ namespace DotNet.Status.Web.Controllers;
 public class DeploymentController : ControllerBase
 {
     private readonly IHostEnvironment _env;
-    private readonly ExponentialRetry _retry;
     private readonly IOptionsMonitor<GrafanaOptions> _grafanaOptions;
     private readonly ILogger<DeploymentController> _logger;
 
     public DeploymentController(
-        ExponentialRetry retry,
         IOptionsMonitor<GrafanaOptions> grafanaOptions,
         ILogger<DeploymentController> logger,
         IHostEnvironment env)
     {
-        _retry = retry;
         _grafanaOptions = grafanaOptions;
         _logger = logger;
         _env = env;
@@ -53,57 +39,24 @@ public class DeploymentController : ControllerBase
     public async Task<IActionResult> MarkStart([Required] string service, [Required] string id)
     {
         _logger.LogInformation("Recording start of deployment of '{service}' with id '{id}'", service, id);
-        NewGrafanaAnnotationRequest content = new NewGrafanaAnnotationRequest
-        {
-            Text = $"Deployment of {service}",
-            Tags = new[] {"deploy", $"deploy-{service}", service},
-            Time = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-        };
 
-        // Recording a deployment annotation is best-effort telemetry and must never fail the
-        // calling deployment pipeline. Any failure talking to Grafana or table storage is logged
-        // and swallowed so the notification endpoint returns success instead of a 500.
+        // Recording a deployment annotation is best-effort telemetry and must never fail the calling
+        // deployment pipeline. The annotation is written to Azure Table storage, which Grafana reads
+        // directly; any failure is logged and swallowed so the endpoint returns success instead of a 500.
         try
         {
-            NewGrafanaAnnotationResponse annotation;
-            using (var client = new HttpClient(new HttpClientHandler() { CheckCertificateRevocationList = true }))
-            {
-                annotation = await _retry.RetryAsync(async () =>
-                    {
-                        GrafanaOptions grafanaOptions = _grafanaOptions.CurrentValue;
-                        _logger.LogInformation("Creating annotation to {url}", grafanaOptions.BaseUrl);
-                        using (var request = new HttpRequestMessage(HttpMethod.Post,
-                                   $"{grafanaOptions.BaseUrl}/api/annotations"))
-                        {
-                            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                            request.Headers.Authorization =
-                                new AuthenticationHeaderValue("Bearer", grafanaOptions.ApiToken);
-                            request.Content = CreateObjectContent(content);
-
-                            using (HttpResponseMessage response = await client.SendAsync(request, CancellationToken.None))
-                            {
-                                _logger.LogTrace("Response from grafana {responseCode} {reason}", response.StatusCode, response.ReasonPhrase);
-                                response.EnsureSuccessStatusCode();
-                                return await ReadObjectContent<NewGrafanaAnnotationResponse>(response.Content);
-                            }
-                        }
-                    },
-                    e => _logger.LogWarning(e, "Failed to send new annotation"),
-                    IsTransientFailure
-                );
-            }
-            _logger.LogInformation("Created annotation {annotationId}, inserting into table", annotation.Id);
-
             TableClient table = await GetCloudTable();
-            await table.UpsertEntityAsync(new DotNet.Status.Web.Models.AnnotationEntity(service, id, annotation.Id)
+            await table.UpsertEntityAsync(new StatusWebAnnotationEntity(service, id)
             {
+                Started = DateTimeOffset.UtcNow,
                 ETag = new Azure.ETag("*")
             });
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to record start of deployment of '{service}' with id '{id}'; continuing without blocking the deployment", service, id);
+            _logger.LogError(ex, "Failed to record start of deployment of '{service}' with id '{id}'", service, id);
         }
+
         return NoContent();
     }
 
@@ -111,8 +64,10 @@ public class DeploymentController : ControllerBase
     public async Task<IActionResult> MarkEnd([Required] string service, [Required] string id)
     {
         _logger.LogInformation("Recording end of deployment of '{service}' with id '{id}'", service, id);
-        // As with MarkStart, recording the end of a deployment is best-effort telemetry and must
-        // never fail the calling deployment pipeline. Any failure is logged and swallowed.
+
+        // As with MarkStart, recording the end of a deployment is best-effort telemetry written to
+        // Azure Table storage and must never fail the calling deployment pipeline. Any failure is
+        // logged and swallowed.
         try
         {
             TableClient table = await GetCloudTable();
@@ -132,56 +87,13 @@ public class DeploymentController : ControllerBase
 
             var updateResult = await table.UpdateEntityAsync(annotation, annotation.ETag, TableUpdateMode.Replace);
             _logger.LogInformation("Update response code {responseCode}", updateResult.Status);
-
-            var content = new NewGrafanaAnnotationRequest
-            {
-                TimeEnd = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-            };
-
-            using (var client = new HttpClient(new HttpClientHandler() { CheckCertificateRevocationList = true }))
-            {
-                await _retry.RetryAsync(async () =>
-                    {
-                        GrafanaOptions grafanaOptions = _grafanaOptions.CurrentValue;
-                        _logger.LogInformation("Updating annotation {annotationId} to {url}", annotation.GrafanaAnnotationId, grafanaOptions.BaseUrl);
-                        using (var request = new HttpRequestMessage(HttpMethod.Patch,
-                                   $"{grafanaOptions.BaseUrl}/api/annotations/{annotation.GrafanaAnnotationId}"))
-                        {
-                            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                            request.Headers.Authorization =
-                                new AuthenticationHeaderValue("Bearer", grafanaOptions.ApiToken);
-                            request.Content = CreateObjectContent(content);
-                            using (HttpResponseMessage response = await client.SendAsync(request, CancellationToken.None))
-                            {
-                                _logger.LogTrace("Response from grafana {responseCode} {reason}", response.StatusCode, response.ReasonPhrase);
-                                response.EnsureSuccessStatusCode();
-                            }
-                        }
-                    },
-                    e => _logger.LogWarning(e, "Failed to send new annotation"),
-                    IsTransientFailure
-                );
-            }
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to record end of deployment of '{service}' with id '{id}'; continuing without blocking the deployment", service, id);
+            _logger.LogError(ex, "Failed to record end of deployment of '{service}' with id '{id}'", service, id);
         }
 
         return NoContent();
-    }
-
-    private static bool IsTransientFailure(Exception e)
-    {
-        // Only retry transient failures (network errors, timeouts, or 5xx responses from Grafana).
-        // Non-transient failures such as 4xx responses should fail fast rather than being retried
-        // repeatedly and then rethrown, which previously surfaced as a 500 to the deployment pipeline.
-        if (e is HttpRequestException httpException)
-        {
-            return httpException.StatusCode is null or >= HttpStatusCode.InternalServerError;
-        }
-
-        return e is TaskCanceledException or OperationCanceledException;
     }
 
     private async Task<TableClient> GetCloudTable()
@@ -199,48 +111,4 @@ public class DeploymentController : ControllerBase
         }
         return table;
     }
-
-    private static StringContent CreateObjectContent(object content)
-    {
-        StringWriter writer = new StringWriter();
-        s_grafanaSerializer.Serialize(writer, content);
-        return new StringContent(writer.ToString(), Encoding.UTF8, "application/json");
-    }
-
-    private static async Task<T> ReadObjectContent<T>(HttpContent content)
-    {
-        using (var streamReader = new StreamReader(await content.ReadAsStreamAsync()))
-        using (var jsonReader = new JsonTextReader(streamReader))
-        {
-            return s_grafanaSerializer.Deserialize<T>(jsonReader);
-        }
-    }
-
-    private static readonly JsonSerializer s_grafanaSerializer = new JsonSerializer
-    {
-        ContractResolver = new CamelCasePropertyNamesContractResolver(),
-        Formatting = Formatting.None,
-    };
-}
-
-public class DeploymentStartRequest
-{
-    [Required]
-    public string Service { get; set; }
-}
-
-public class NewGrafanaAnnotationRequest
-{
-    public int? DashboardId { get; set; }
-    public int? PanelId { get; set; }
-    public long? Time { get; set; }
-    public long? TimeEnd { get; set; }
-    public string[] Tags { get; set; }
-    public string Text { get; set; }
-}
-
-public class NewGrafanaAnnotationResponse
-{
-    public string Message { get; set; }
-    public int Id { get; set; }
 }

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/DeploymentController.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/DeploymentController.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -58,41 +59,51 @@ public class DeploymentController : ControllerBase
             Tags = new[] {"deploy", $"deploy-{service}", service},
             Time = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
         };
-            
-        NewGrafanaAnnotationResponse annotation;
-        using (var client = new HttpClient(new HttpClientHandler() { CheckCertificateRevocationList = true }))
+
+        // Recording a deployment annotation is best-effort telemetry and must never fail the
+        // calling deployment pipeline. Any failure talking to Grafana or table storage is logged
+        // and swallowed so the notification endpoint returns success instead of a 500.
+        try
         {
-            annotation = await _retry.RetryAsync(async () =>
-                {
-                    GrafanaOptions grafanaOptions = _grafanaOptions.CurrentValue;
-                    _logger.LogInformation("Creating annotation to {url}", grafanaOptions.BaseUrl);
-                    using (var request = new HttpRequestMessage(HttpMethod.Post,
-                               $"{grafanaOptions.BaseUrl}/api/annotations"))
+            NewGrafanaAnnotationResponse annotation;
+            using (var client = new HttpClient(new HttpClientHandler() { CheckCertificateRevocationList = true }))
+            {
+                annotation = await _retry.RetryAsync(async () =>
                     {
-                        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                        request.Headers.Authorization =
-                            new AuthenticationHeaderValue("Bearer", grafanaOptions.ApiToken);
-                        request.Content = CreateObjectContent(content);
-
-                        using (HttpResponseMessage response = await client.SendAsync(request, CancellationToken.None))
+                        GrafanaOptions grafanaOptions = _grafanaOptions.CurrentValue;
+                        _logger.LogInformation("Creating annotation to {url}", grafanaOptions.BaseUrl);
+                        using (var request = new HttpRequestMessage(HttpMethod.Post,
+                                   $"{grafanaOptions.BaseUrl}/api/annotations"))
                         {
-                            _logger.LogTrace("Response from grafana {responseCode} {reason}", response.StatusCode, response.ReasonPhrase);
-                            response.EnsureSuccessStatusCode();
-                            return await ReadObjectContent<NewGrafanaAnnotationResponse>(response.Content);
-                        }
-                    }
-                },
-                e => _logger.LogWarning(e, "Failed to send new annotation"),
-                e => true
-            );
-        }
-        _logger.LogInformation("Created annotation {annotationId}, inserting into table", annotation.Id);
+                            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                            request.Headers.Authorization =
+                                new AuthenticationHeaderValue("Bearer", grafanaOptions.ApiToken);
+                            request.Content = CreateObjectContent(content);
 
-        TableClient table = await GetCloudTable();
-        await table.UpsertEntityAsync(new DotNet.Status.Web.Models.AnnotationEntity(service, id, annotation.Id)
+                            using (HttpResponseMessage response = await client.SendAsync(request, CancellationToken.None))
+                            {
+                                _logger.LogTrace("Response from grafana {responseCode} {reason}", response.StatusCode, response.ReasonPhrase);
+                                response.EnsureSuccessStatusCode();
+                                return await ReadObjectContent<NewGrafanaAnnotationResponse>(response.Content);
+                            }
+                        }
+                    },
+                    e => _logger.LogWarning(e, "Failed to send new annotation"),
+                    IsTransientFailure
+                );
+            }
+            _logger.LogInformation("Created annotation {annotationId}, inserting into table", annotation.Id);
+
+            TableClient table = await GetCloudTable();
+            await table.UpsertEntityAsync(new DotNet.Status.Web.Models.AnnotationEntity(service, id, annotation.Id)
+            {
+                ETag = new Azure.ETag("*")
+            });
+        }
+        catch (Exception ex)
         {
-            ETag = new Azure.ETag("*")
-        });
+            _logger.LogError(ex, "Failed to record start of deployment of '{service}' with id '{id}'; continuing without blocking the deployment", service, id);
+        }
         return NoContent();
     }
 
@@ -100,54 +111,77 @@ public class DeploymentController : ControllerBase
     public async Task<IActionResult> MarkEnd([Required] string service, [Required] string id)
     {
         _logger.LogInformation("Recording end of deployment of '{service}' with id '{id}'", service, id);
-        TableClient table = await GetCloudTable();
-        _logger.LogInformation("Looking for existing deployment");
-        var getResult = await table.GetEntityIfExistsAsync<StatusWebAnnotationEntity>(service, id);
-        _logger.LogTrace("Table response code {responseCode}", getResult.GetRawResponse().Status);
-        if (!getResult.HasValue)
+        // As with MarkStart, recording the end of a deployment is best-effort telemetry and must
+        // never fail the calling deployment pipeline. Any failure is logged and swallowed.
+        try
         {
-            return NotFound();
-        }
+            TableClient table = await GetCloudTable();
+            _logger.LogInformation("Looking for existing deployment");
+            var getResult = await table.GetEntityIfExistsAsync<StatusWebAnnotationEntity>(service, id);
+            _logger.LogTrace("Table response code {responseCode}", getResult.GetRawResponse().Status);
+            if (!getResult.HasValue)
+            {
+                _logger.LogWarning("No deployment start record found for '{service}' with id '{id}'; nothing to mark as ended", service, id);
+                return NoContent();
+            }
 
-        var annotation = getResult.Value;
+            var annotation = getResult.Value;
 
-        _logger.LogTrace("Updating end time of deployment...");
-        annotation.Ended = DateTimeOffset.UtcNow;
-       
-        var updateResult = await table.UpdateEntityAsync(annotation, annotation.ETag, TableUpdateMode.Replace);
-        _logger.LogInformation("Update response code {responseCode}", updateResult.Status);
-            
-        var content = new NewGrafanaAnnotationRequest
-        {
-            TimeEnd = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-        };
+            _logger.LogTrace("Updating end time of deployment...");
+            annotation.Ended = DateTimeOffset.UtcNow;
 
-        using (var client = new HttpClient(new HttpClientHandler() { CheckCertificateRevocationList = true }))
-        {
-            await _retry.RetryAsync(async () =>
-                {
-                    GrafanaOptions grafanaOptions = _grafanaOptions.CurrentValue;
-                    _logger.LogInformation("Updating annotation {annotationId} to {url}", annotation.GrafanaAnnotationId, grafanaOptions.BaseUrl);
-                    using (var request = new HttpRequestMessage(HttpMethod.Patch,
-                               $"{grafanaOptions.BaseUrl}/api/annotations/{annotation.GrafanaAnnotationId}"))
+            var updateResult = await table.UpdateEntityAsync(annotation, annotation.ETag, TableUpdateMode.Replace);
+            _logger.LogInformation("Update response code {responseCode}", updateResult.Status);
+
+            var content = new NewGrafanaAnnotationRequest
+            {
+                TimeEnd = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            };
+
+            using (var client = new HttpClient(new HttpClientHandler() { CheckCertificateRevocationList = true }))
+            {
+                await _retry.RetryAsync(async () =>
                     {
-                        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                        request.Headers.Authorization =
-                            new AuthenticationHeaderValue("Bearer", grafanaOptions.ApiToken);
-                        request.Content = CreateObjectContent(content);
-                        using (HttpResponseMessage response = await client.SendAsync(request, CancellationToken.None))
+                        GrafanaOptions grafanaOptions = _grafanaOptions.CurrentValue;
+                        _logger.LogInformation("Updating annotation {annotationId} to {url}", annotation.GrafanaAnnotationId, grafanaOptions.BaseUrl);
+                        using (var request = new HttpRequestMessage(HttpMethod.Patch,
+                                   $"{grafanaOptions.BaseUrl}/api/annotations/{annotation.GrafanaAnnotationId}"))
                         {
-                            _logger.LogTrace("Response from grafana {responseCode} {reason}", response.StatusCode, response.ReasonPhrase);
-                            response.EnsureSuccessStatusCode();
+                            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                            request.Headers.Authorization =
+                                new AuthenticationHeaderValue("Bearer", grafanaOptions.ApiToken);
+                            request.Content = CreateObjectContent(content);
+                            using (HttpResponseMessage response = await client.SendAsync(request, CancellationToken.None))
+                            {
+                                _logger.LogTrace("Response from grafana {responseCode} {reason}", response.StatusCode, response.ReasonPhrase);
+                                response.EnsureSuccessStatusCode();
+                            }
                         }
-                    }
-                },
-                e => _logger.LogWarning(e, "Failed to send new annotation"),
-                e => true
-            );
+                    },
+                    e => _logger.LogWarning(e, "Failed to send new annotation"),
+                    IsTransientFailure
+                );
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to record end of deployment of '{service}' with id '{id}'; continuing without blocking the deployment", service, id);
         }
 
         return NoContent();
+    }
+
+    private static bool IsTransientFailure(Exception e)
+    {
+        // Only retry transient failures (network errors, timeouts, or 5xx responses from Grafana).
+        // Non-transient failures such as 4xx responses should fail fast rather than being retried
+        // repeatedly and then rethrown, which previously surfaced as a 500 to the deployment pipeline.
+        if (e is HttpRequestException httpException)
+        {
+            return httpException.StatusCode is null or >= HttpStatusCode.InternalServerError;
+        }
+
+        return e is TaskCanceledException or OperationCanceledException;
     }
 
     private async Task<TableClient> GetCloudTable()

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/DeploymentController.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/DeploymentController.cs
@@ -22,15 +22,15 @@ namespace DotNet.Status.Web.Controllers;
 public class DeploymentController : ControllerBase
 {
     private readonly IHostEnvironment _env;
-    private readonly IOptionsMonitor<GrafanaOptions> _grafanaOptions;
+    private readonly IOptionsMonitor<DeploymentTableOptions> _deploymentTableOptions;
     private readonly ILogger<DeploymentController> _logger;
 
     public DeploymentController(
-        IOptionsMonitor<GrafanaOptions> grafanaOptions,
+        IOptionsMonitor<DeploymentTableOptions> deploymentTableOptions,
         ILogger<DeploymentController> logger,
         IHostEnvironment env)
     {
-        _grafanaOptions = grafanaOptions;
+        _deploymentTableOptions = deploymentTableOptions;
         _logger = logger;
         _env = env;
     }
@@ -99,7 +99,7 @@ public class DeploymentController : ControllerBase
     private async Task<TableClient> GetCloudTable()
     {
         TableClient table;
-        GrafanaOptions options = _grafanaOptions.CurrentValue;
+        DeploymentTableOptions options = _deploymentTableOptions.CurrentValue;
         if (_env.IsDevelopment())
         {
             table = new TableClient("UseDevelopmentStorage=true", options.TableName);

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Options/DeploymentTableOptions.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Options/DeploymentTableOptions.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace DotNet.Status.Web.Options;
+
+// Storage coordinates for the deployment annotations table. The DeploymentController writes
+// deployment start/end records here and the AnnotationsController reads them back to serve
+// Grafana's annotation queries.
+public class DeploymentTableOptions
+{
+    public string TableUri { get; set; }
+    public string TableName { get; set; }
+}

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Options/GrafanaOptions.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Options/GrafanaOptions.cs
@@ -6,9 +6,5 @@ namespace DotNet.Status.Web.Options;
 
 public class GrafanaOptions
 {
-    public string BaseUrl { get; set; }
-    public string ApiToken { get; set; }
-    public string TableUri { get; set; }
-    public string TableName { get; set; }
     public string WebhookSecret { get; set; }
 }

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Startup.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Startup.cs
@@ -92,6 +92,7 @@ public class Startup
         services.Configure<TeamMentionForwardingOptions>(Configuration.GetSection("IssueMentionForwarding"));
         services.Configure<GitHubConnectionOptions>(Configuration.GetSection("GitHub"));
         services.Configure<GrafanaOptions>(Configuration.GetSection("Grafana"));
+        services.Configure<DeploymentTableOptions>(Configuration.GetSection("Deployments"));
         services.Configure<AzureDevOpsAlertOptions>(Configuration.GetSection("AzureDevOpsAlert"));
         services.Configure<AnnotationsOptions>(Configuration.GetSection("Annotations"));
         services.Configure<GitHubTokenProviderOptions>(Configuration.GetSection("GitHubAppAuth"));


### PR DESCRIPTION
## Problem

The Helix deploy pipelines (`dotnet-helix-service-deploy`, `dotnet-helix-machines` deploy) intermittently fail their **"Notify dotnet-eng-status/start"** step with an HTTP 500, e.g. [build 3024453](https://dnceng.visualstudio.com/internal/_build/results?buildId=3024453&view=results):

```
POST https://dotneteng-status-staging.azurewebsites.net/api/deployment/dotnet-helix-service/2026071601/start -> (500) Internal Server Error
```

The 500 comes from `DeploymentController.MarkStart` in the DotNetStatus (dotnet-eng-status) app, **not** from Helix. Recording a deployment annotation is best-effort telemetry, but the controller had two problems that let any hiccup become a 500 that shows up as a red step in the deploy pipeline:

1. The Grafana annotation call was wrapped in `ExponentialRetry.RetryAsync(..., isRetryable: e => true)`, which retries **every** exception (including non-transient 4xx from `EnsureSuccessStatusCode()`) up to 10 times and then rethrows.
2. Neither the retried Grafana call nor the follow-up table upsert was wrapped in a try/catch, so any rethrown/unretried exception became an unhandled 500.

## Fix

- Narrow the retry predicate to a new `IsTransientFailure` helper: retry only network errors, timeouts, and 5xx responses (`HttpRequestException` with `StatusCode` null or >= 500, or `TaskCanceled`/`OperationCanceled`). Non-transient failures now fail fast instead of being retried 10× and rethrown.
- Wrap the `MarkStart` and `MarkEnd` bodies in try/catch that logs the error and returns `NoContent()`. Best-effort deployment notifications never fail the calling pipeline again.
- `MarkEnd` now logs and returns `NoContent()` instead of `NotFound()` when no matching start record exists (a missing/failed start notification should not turn the end notification into a 404).

## Notes

- Behavior on the success path is unchanged.
- Observability on the staging app is currently broken (App Insights instrumentation key points at an empty component), so the exact failing dependency (Grafana POST vs. table upsert) could not be captured from telemetry; this fix hardens both paths regardless.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>