### PR TITLE
Prompt for GitHub access token expiration duration during rotation

### DIFF
--- a/src/SecretManager/Microsoft.DncEng.SecretManager.Tests/GitHubAccessTokenTests.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager.Tests/GitHubAccessTokenTests.cs
@@ -19,10 +19,12 @@ public class GitHubAccessTokenTests
     }
 
     [Test]
-    [TestCase("1", true, 1, Description = "Minimum allowed duration")]
+    [TestCase("7", true, 7, Description = "Minimum allowed duration")]
     [TestCase("90", true, 90, Description = "Typical duration")]
     [TestCase("366", true, 366, Description = "Maximum allowed duration")]
-    [TestCase("0", false, 0, Description = "Below minimum")]
+    [TestCase("6", false, 6, Description = "Just below minimum")]
+    [TestCase("1", false, 1, Description = "Below minimum")]
+    [TestCase("0", false, 0, Description = "Zero")]
     [TestCase("367", false, 367, Description = "Above maximum")]
     [TestCase("-5", false, -5, Description = "Negative")]
     [TestCase("abc", false, 0, Description = "Not a number")]
@@ -42,8 +44,8 @@ public class GitHubAccessTokenTests
     [Test]
     [TestCase(90, 60, Description = "1/3 of 90 days remains -> rotate after 60 days")]
     [TestCase(30, 20, Description = "1/3 of 30 days remains -> rotate after 20 days")]
-    [TestCase(3, 2, Description = "Small duration")]
-    [TestCase(1, 0, Description = "Minimum duration rotates immediately")]
+    [TestCase(9, 6, Description = "Small duration")]
+    [TestCase(7, 4, Description = "Minimum allowed duration")]
     public void ComputeNextRotationOn_ShouldRotateWhenAThirdRemains(int durationDays, int expectedDeltaDays)
     {
         var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);

--- a/src/SecretManager/Microsoft.DncEng.SecretManager.Tests/GitHubAccessTokenTests.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager.Tests/GitHubAccessTokenTests.cs
@@ -1,0 +1,87 @@
+using System;
+using AwesomeAssertions;
+using Microsoft.DncEng.CommandLineLib;
+using Microsoft.DncEng.SecretManager.SecretTypes;
+using Moq;
+using NUnit.Framework;
+
+namespace Microsoft.DncEng.SecretManager.Tests;
+
+[TestFixture]
+public class GitHubAccessTokenTests
+{
+    private TestableGitHubAccessToken _token;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _token = new TestableGitHubAccessToken(new Mock<ISystemClock>().Object, new Mock<IConsole>().Object);
+    }
+
+    [Test]
+    [TestCase("1", true, 1, Description = "Minimum allowed duration")]
+    [TestCase("90", true, 90, Description = "Typical duration")]
+    [TestCase("366", true, 366, Description = "Maximum allowed duration")]
+    [TestCase("0", false, 0, Description = "Below minimum")]
+    [TestCase("367", false, 367, Description = "Above maximum")]
+    [TestCase("-5", false, -5, Description = "Negative")]
+    [TestCase("abc", false, 0, Description = "Not a number")]
+    [TestCase("", false, 0, Description = "Empty string")]
+    [TestCase("30.5", false, 0, Description = "Not a whole number")]
+    public void TryParseExpirationInDays_ShouldValidateBounds(string value, bool expectedResult, int expectedParsed)
+    {
+        var result = _token.TestTryParseExpirationInDays(value, out var parsed);
+
+        result.Should().Be(expectedResult);
+        if (expectedResult)
+        {
+            parsed.Should().Be(expectedParsed);
+        }
+    }
+
+    [Test]
+    [TestCase(90, 60, Description = "1/3 of 90 days remains -> rotate after 60 days")]
+    [TestCase(30, 20, Description = "1/3 of 30 days remains -> rotate after 20 days")]
+    [TestCase(3, 2, Description = "Small duration")]
+    [TestCase(1, 0, Description = "Minimum duration rotates immediately")]
+    public void ComputeNextRotationOn_ShouldRotateWhenAThirdRemains(int durationDays, int expectedDeltaDays)
+    {
+        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var nextRotationOn = _token.TestComputeNextRotationOn(now, durationDays);
+
+        nextRotationOn.Should().Be(now.AddDays(expectedDeltaDays));
+    }
+
+    [Test]
+    public void ComputeNextRotationOn_ShouldFallBeforeExpiration()
+    {
+        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        const int durationDays = 90;
+
+        var expiresOn = now.AddDays(durationDays);
+        var nextRotationOn = _token.TestComputeNextRotationOn(now, durationDays);
+
+        nextRotationOn.Should().BeAfter(now);
+        nextRotationOn.Should().BeBefore(expiresOn);
+    }
+
+    // Test helper class exposing the protected static members for testing.
+    private class TestableGitHubAccessToken : GitHubAccessToken
+    {
+        public TestableGitHubAccessToken(ISystemClock clock, IConsole console)
+            : base(clock, console)
+        {
+        }
+
+        public bool TestTryParseExpirationInDays(string value, out int parsedValue)
+        {
+            return TryParseExpirationInDays(value, out parsedValue);
+        }
+
+        public DateTimeOffset TestComputeNextRotationOn(DateTimeOffset now, int expirationInDays)
+        {
+            return ComputeNextRotationOn(now, expirationInDays);
+        }
+    }
+}

--- a/src/SecretManager/Microsoft.DncEng.SecretManager.Tests/GitHubAccessTokenTests.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager.Tests/GitHubAccessTokenTests.cs
@@ -20,12 +20,13 @@ public class GitHubAccessTokenTests
 
     [Test]
     [TestCase("7", true, 7, Description = "Minimum allowed duration")]
-    [TestCase("90", true, 90, Description = "Typical duration")]
-    [TestCase("366", true, 366, Description = "Maximum allowed duration")]
+    [TestCase("20", true, 20, Description = "Typical duration")]
+    [TestCase("30", true, 30, Description = "Maximum allowed duration")]
     [TestCase("6", false, 6, Description = "Just below minimum")]
     [TestCase("1", false, 1, Description = "Below minimum")]
     [TestCase("0", false, 0, Description = "Zero")]
-    [TestCase("367", false, 367, Description = "Above maximum")]
+    [TestCase("31", false, 31, Description = "Just above maximum")]
+    [TestCase("90", false, 90, Description = "Above maximum")]
     [TestCase("-5", false, -5, Description = "Negative")]
     [TestCase("abc", false, 0, Description = "Not a number")]
     [TestCase("", false, 0, Description = "Empty string")]
@@ -42,8 +43,8 @@ public class GitHubAccessTokenTests
     }
 
     [Test]
-    [TestCase(90, 60, Description = "1/3 of 90 days remains -> rotate after 60 days")]
     [TestCase(30, 20, Description = "1/3 of 30 days remains -> rotate after 20 days")]
+    [TestCase(15, 10, Description = "1/3 of 15 days remains -> rotate after 10 days")]
     [TestCase(9, 6, Description = "Small duration")]
     [TestCase(7, 4, Description = "Minimum allowed duration")]
     public void ComputeNextRotationOn_ShouldRotateWhenAThirdRemains(int durationDays, int expectedDeltaDays)
@@ -59,7 +60,7 @@ public class GitHubAccessTokenTests
     public void ComputeNextRotationOn_ShouldFallBeforeExpiration()
     {
         var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
-        const int durationDays = 90;
+        const int durationDays = 30;
 
         var expiresOn = now.AddDays(durationDays);
         var nextRotationOn = _token.TestComputeNextRotationOn(now, durationDays);

--- a/src/SecretManager/Microsoft.DncEng.SecretManager.Tests/GitHubAccessTokenTests.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager.Tests/GitHubAccessTokenTests.cs
@@ -33,7 +33,7 @@ public class GitHubAccessTokenTests
     [TestCase("30.5", false, 0, Description = "Not a whole number")]
     public void TryParseExpirationInDays_ShouldValidateBounds(string value, bool expectedResult, int expectedParsed)
     {
-        var result = _token.TestTryParseExpirationInDays(value, out var parsed);
+        bool result = _token.TestTryParseExpirationInDays(value, out int parsed);
 
         result.Should().Be(expectedResult);
         if (expectedResult)
@@ -49,9 +49,9 @@ public class GitHubAccessTokenTests
     [TestCase(7, 4, Description = "Minimum allowed duration")]
     public void ComputeNextRotationOn_ShouldRotateWhenAThirdRemains(int durationDays, int expectedDeltaDays)
     {
-        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        DateTimeOffset now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
-        var nextRotationOn = _token.TestComputeNextRotationOn(now, durationDays);
+        DateTimeOffset nextRotationOn = _token.TestComputeNextRotationOn(now, durationDays);
 
         nextRotationOn.Should().Be(now.AddDays(expectedDeltaDays));
     }
@@ -59,11 +59,11 @@ public class GitHubAccessTokenTests
     [Test]
     public void ComputeNextRotationOn_ShouldFallBeforeExpiration()
     {
-        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        DateTimeOffset now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
         const int durationDays = 30;
 
-        var expiresOn = now.AddDays(durationDays);
-        var nextRotationOn = _token.TestComputeNextRotationOn(now, durationDays);
+        DateTimeOffset expiresOn = now.AddDays(durationDays);
+        DateTimeOffset nextRotationOn = _token.TestComputeNextRotationOn(now, durationDays);
 
         nextRotationOn.Should().BeAfter(now);
         nextRotationOn.Should().BeBefore(expiresOn);

--- a/src/SecretManager/Microsoft.DncEng.SecretManager/Readme.md
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/Readme.md
@@ -341,6 +341,10 @@ parameters:
 ```
 
 ### GitHub access token
+During rotation you will be prompted to enter the token's expiration duration in
+days (1-366). The entered duration is shown in the on-screen instructions for
+creating the token on github.com and also sets the secret's expiration; the
+secret is scheduled to rotate once about one third of that duration remains.
 ```yaml
 type: github-access-token
 parameters:

--- a/src/SecretManager/Microsoft.DncEng.SecretManager/Readme.md
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/Readme.md
@@ -342,7 +342,7 @@ parameters:
 
 ### GitHub access token
 During rotation you will be prompted to enter the token's expiration duration in
-days (1-366). The entered duration is shown in the on-screen instructions for
+days (7-366). The entered duration is shown in the on-screen instructions for
 creating the token on github.com and also sets the secret's expiration; the
 secret is scheduled to rotate once about one third of that duration remains.
 ```yaml

--- a/src/SecretManager/Microsoft.DncEng.SecretManager/Readme.md
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/Readme.md
@@ -342,7 +342,7 @@ parameters:
 
 ### GitHub access token
 During rotation you will be prompted to enter the token's expiration duration in
-days (7-366). The entered duration is shown in the on-screen instructions for
+days (7-30). The entered duration is shown in the on-screen instructions for
 creating the token on github.com and also sets the secret's expiration; the
 secret is scheduled to rotate once about one third of that duration remains.
 ```yaml

--- a/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/GitHubAccessToken.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/GitHubAccessToken.cs
@@ -9,8 +9,8 @@ namespace Microsoft.DncEng.SecretManager.SecretTypes;
 public class GitHubAccessToken : GitHubAccountInteractiveSecretType<GitHubAccessToken.Parameters>
 {
     // GitHub allows personal access tokens to be created with an expiration
-    // between 1 and 366 days (or no expiration, which we do not support here).
-    private const int _minExpirationInDays = 1;
+    // between 1 and 366 days, but we require a minimum of 7 days.
+    private const int _minExpirationInDays = 7;
     private const int _maxExpirationInDays = 366;
 
     public class Parameters

--- a/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/GitHubAccessToken.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/GitHubAccessToken.cs
@@ -8,10 +8,10 @@ namespace Microsoft.DncEng.SecretManager.SecretTypes;
 [Name("github-access-token")]
 public class GitHubAccessToken : GitHubAccountInteractiveSecretType<GitHubAccessToken.Parameters>
 {
-    // GitHub allows personal access tokens to be created with an expiration
-    // between 1 and 366 days, but we require a minimum of 7 days.
+    // GitHub allows a higher maximum, but we deliberately restrict access token
+    // lifetimes to between 7 and 30 days.
     private const int _minExpirationInDays = 7;
-    private const int _maxExpirationInDays = 366;
+    private const int _maxExpirationInDays = 30;
 
     public class Parameters
     {

--- a/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/GitHubAccessToken.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/GitHubAccessToken.cs
@@ -31,20 +31,20 @@ public class GitHubAccessToken : GitHubAccountInteractiveSecretType<GitHubAccess
             throw new HumanInterventionRequiredException($"User intervention required for creation or rotation of a GitHub access token.");
         }
 
-        var expirationInDays = await Console.PromptAndValidateAsync<int>(
+        int expirationInDays = await Console.PromptAndValidateAsync<int>(
             "expiration in days",
             $"Expiration must be a whole number of days between {_minExpirationInDays} and {_maxExpirationInDays}.",
             TryParseExpirationInDays);
 
-        var now = Clock.UtcNow;
-        var expiresOn = now.AddDays(expirationInDays);
-        var nextRotationOn = ComputeNextRotationOn(now, expirationInDays);
+        DateTimeOffset now = Clock.UtcNow;
+        DateTimeOffset expiresOn = now.AddDays(expirationInDays);
+        DateTimeOffset nextRotationOn = ComputeNextRotationOn(now, expirationInDays);
 
         const string helpUrl = "https://github.com/settings/tokens";
         Console.WriteLine($"When creating the new token, set the expiration to {expirationInDays}d in the future ({expiresOn:yyyy-MM-dd}).");
         await ShowGitHubLoginInformation(context, parameters.GitHubBotAccountSecret, helpUrl, parameters.GitHubBotAccountName);
 
-        var pat = await Console.PromptAndValidateAsync("PAT",
+        string pat = await Console.PromptAndValidateAsync("PAT",
             "PAT must have at least 40 characters.",
             value => value != null && value.Length >= 40);
 

--- a/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/GitHubAccessToken.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/GitHubAccessToken.cs
@@ -8,8 +8,10 @@ namespace Microsoft.DncEng.SecretManager.SecretTypes;
 [Name("github-access-token")]
 public class GitHubAccessToken : GitHubAccountInteractiveSecretType<GitHubAccessToken.Parameters>
 {
-    private const int _nextRotationOnDeltaDays = 30;
-    private const int _expirationInDays = 90;
+    // GitHub allows personal access tokens to be created with an expiration
+    // between 1 and 366 days (or no expiration, which we do not support here).
+    private const int _minExpirationInDays = 1;
+    private const int _maxExpirationInDays = 366;
 
     public class Parameters
     {
@@ -29,14 +31,39 @@ public class GitHubAccessToken : GitHubAccountInteractiveSecretType<GitHubAccess
             throw new HumanInterventionRequiredException($"User intervention required for creation or rotation of a GitHub access token.");
         }
 
+        var expirationInDays = await Console.PromptAndValidateAsync<int>(
+            "expiration in days",
+            $"Expiration must be a whole number of days between {_minExpirationInDays} and {_maxExpirationInDays}.",
+            TryParseExpirationInDays);
+
+        var now = Clock.UtcNow;
+        var expiresOn = now.AddDays(expirationInDays);
+        var nextRotationOn = ComputeNextRotationOn(now, expirationInDays);
+
         const string helpUrl = "https://github.com/settings/tokens";
-        Console.WriteLine($"When creating the new token, set the expiration to {_expirationInDays}d in the future ({Clock.UtcNow.AddDays(_expirationInDays).ToString("yyyy-MM-dd")}).");
+        Console.WriteLine($"When creating the new token, set the expiration to {expirationInDays}d in the future ({expiresOn:yyyy-MM-dd}).");
         await ShowGitHubLoginInformation(context, parameters.GitHubBotAccountSecret, helpUrl, parameters.GitHubBotAccountName);
 
         var pat = await Console.PromptAndValidateAsync("PAT",
             "PAT must have at least 40 characters.",
             value => value != null && value.Length >= 40);
 
-        return new SecretData(pat, DateTimeOffset.MaxValue, Clock.UtcNow.AddDays(_nextRotationOnDeltaDays));
+        Console.WriteLine($"Next rotation was set to {nextRotationOn:yyyy-MM-dd}.");
+
+        return new SecretData(pat, expiresOn, nextRotationOn);
+    }
+
+    // Rotate once roughly two thirds of the way through the token's lifetime,
+    // i.e. when about one third of the entered duration remains before expiration.
+    protected static DateTimeOffset ComputeNextRotationOn(DateTimeOffset now, int expirationInDays)
+    {
+        return now.AddDays(expirationInDays * 2 / 3);
+    }
+
+    protected static bool TryParseExpirationInDays(string value, out int parsedValue)
+    {
+        return int.TryParse(value, out parsedValue)
+            && parsedValue >= _minExpirationInDays
+            && parsedValue <= _maxExpirationInDays;
     }
 }


### PR DESCRIPTION
## Summary

The `github-access-token` SecretManager secret type previously hard-coded a 90-day expiration (display only) and a fixed 30-day rotation, with `ExpiresOn` set to `DateTimeOffset.MaxValue`. Operators now enter the token's expiration **duration in days** interactively during rotation, and that value drives the on-screen GitHub instructions, the secret's real `ExpiresOn`, and its `NextRotationOn`.

## Changes

- **`SecretTypes/GitHubAccessToken.cs`**
  - Prompts for expiration duration via the existing `PromptAndValidateAsync<int>` helper.
  - Validates a whole number of days in **7–30** (we deliberately restrict below GitHub's allowed maximum); out-of-range/invalid input prints an error and re-prompts (3 attempts, then throws).
  - `ExpiresOn = now + duration`; `NextRotationOn = now + duration * 2/3` (rotate when ~1/3 of the lifetime remains).
  - On-screen GitHub guidance and a "next rotation" line reflect the entered duration.
  - Non-interactive runs still throw `HumanInterventionRequiredException`; PAT length check and login flow unchanged.
  - Uses explicit types (no `var`).
- **`Readme.md`** — documents the new prompt and the 7–30 day range.
- **New `Microsoft.DncEng.SecretManager.Tests/GitHubAccessTokenTests.cs`** — 17 tests covering duration-bound validation (min/max/negative/non-numeric/non-integer) and the rotation/expiration date math.

## Validation

`dotnet test` on `Microsoft.DncEng.SecretManager.Tests` (filtered to `GitHubAccessTokenTests`): **17 passed, 0 failed**.