### PR TITLE
Fix CG alerts: bump System.Security.Cryptography.Xml 8.0.1 -> 8.0.4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -90,7 +90,7 @@
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.1" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.4" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.7" />
     <PackageVersion Include="System.Text.Json" Version="9.0.7" />
     <PackageVersion Include="WindowsAzure.Storage" Version="9.3.3" />


### PR DESCRIPTION
Resolves Component Governance high-severity alerts for `System.Security.Cryptography.Xml` **8.0.1** in `dotnet/dnceng`.

Bumps the pinned `System.Security.Cryptography.Xml` 8.0.1 -> **8.0.4** (latest 8.0.x servicing) in `Directory.Packages.props`.

No coherent-set changes needed: Xml 8.0.4 only requires `System.Security.Cryptography.Pkcs >= 8.0.1` (unpinned here, resolves fine) and the pinned `System.Formats.Asn1` 8.0.1 still satisfies the transitive graph, so no NU1605 downgrade.

Fixes AzDO work items: 11796, 11797, 11798, 11799, 11847
CVEs: CVE-2026-50525, CVE-2026-47304, CVE-2026-47302, CVE-2026-50648, CVE-2026-50527