### PR TITLE
[Rollout] Production rollout, 2026-07-22

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -90,7 +90,7 @@
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.1" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.4" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.7" />
     <PackageVersion Include="System.Text.Json" Version="9.0.7" />
     <PackageVersion Include="WindowsAzure.Storage" Version="9.3.3" />

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Pages/Index.cshtml
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Pages/Index.cshtml
@@ -2,7 +2,7 @@
 @using System.Security.Claims
 @using System.Reflection
 @{
-    ViewData["Title"] = "Home page";
+    ViewData["Title"] = ".NET Engineering Status - Home";
     var appVersion = Assembly.GetEntryAssembly()
                         ?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
                         ?.InformationalVersion?.ToString() ?? "Unknown";


### PR DESCRIPTION
## Rollout for dotnet-dnceng

**Deployment date:** 2026-07-22
**Rollout branch:** `rollout/2026-07-22` cut from last green CI @ `0b3cf25f`
**Work item:** _(to be added — shared rollout work item is created and back-linked after all PRs are open)_
**Merge strategy:** Merge commit (do NOT squash, do NOT rebase)

### Included commits

1. `d4996a6b` Home page title accessibility fix — Haruna
2. `3f001e47` Fix non-descriptive home page title (#6640) — Haruna
3. `0b3cf25f` Fix CG alerts: bump System.Security.Cryptography.Xml 8.0.1 -> 8.0.4 (#6648) — Missy

### Changes included

#### Bug fixes / Accessibility
- PR #6640 - Fix non-descriptive home page title

#### Internal Infrastructure Improvements / Security
- PR #6648 - Fix CG alerts: bump System.Security.Cryptography.Xml 8.0.1 -> 8.0.4

### Reviewers requested
- Haruna Ogweda (`haruna99`)
- Missy Messa (`missymessa`)
- Team: `@dotnet/dnceng`
