### PR TITLE
Remove stale helixview-prod portal link from serviceAvailability dashboard

### DIFF
--- a/src/Monitoring/Monitoring.DncEng/dashboard/dnceng/serviceAvailability.dashboard.json
+++ b/src/Monitoring/Monitoring.DncEng/dashboard/dnceng/serviceAvailability.dashboard.json
@@ -2902,13 +2902,7 @@
             "y": 50
           },
           "id": 19,
-          "links": [
-            {
-              "targetBlank": true,
-              "title": "Azure Portal: Average Response Time",
-              "url": "https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/blade/Microsoft_Azure_MonitoringAz/MetricsV4/Referer/MetricsExplorer/ResourceId/%2Fsubscriptions%2F68672ab8-de0c-40f1-8d1b-ffb20bd62c0f%2FresourceGroups%2Fhelixinfrarg%2Fproviders%2FMicrosoft.Web%2Fsites%2Fhelixview-prod/TimeContext/%7B%22relative%22%3A%7B%22duration%22%3A2592000000%7D%2C%22showUTCTime%22%3Afalse%2C%22grain%22%3A1%7D/ChartDefinition/%7B%22v2charts%22%3A%5B%7B%22metrics%22%3A%5B%7B%22resourceMetadata%22%3A%7B%22id%22%3A%22%2Fsubscriptions%2F68672ab8-de0c-40f1-8d1b-ffb20bd62c0f%2FresourceGroups%2Fhelixinfrarg%2Fproviders%2FMicrosoft.Web%2Fsites%2Fhelixview-prod%22%7D%2C%22name%22%3A%22AverageResponseTime%22%2C%22aggregationType%22%3A4%2C%22namespace%22%3A%22microsoft.web%2Fsites%22%2C%22metricVisualization%22%3A%7B%22displayName%22%3A%22Average%20Response%20Time%22%2C%22resourceDisplayName%22%3A%22helixview-prod%22%7D%7D%5D%2C%22title%22%3A%22Average%20Response%20Time%22%2C%22titleKind%22%3A2%2C%22visualization%22%3A%7B%22chartType%22%3A2%2C%22legendVisualization%22%3A%7B%22isVisible%22%3Atrue%2C%22position%22%3A2%2C%22hideSubtitle%22%3Afalse%7D%2C%22axisVisualization%22%3A%7B%22x%22%3A%7B%22isVisible%22%3Atrue%2C%22axisType%22%3A2%7D%2C%22y%22%3A%7B%22isVisible%22%3Atrue%2C%22axisType%22%3A1%7D%7D%7D%7D%5D%7D"
-            }
-          ],
+          "links": [],
           "options": {
             "legend": {
               "calcs": [


### PR DESCRIPTION
## What
Removes a stale Azure Portal deep-link from the `Helix API Average Response Time` panel in `serviceAvailability.dashboard.json`.

## Why
The `helixview-prod` App Service and its orphaned App Service Plan (`helixview-prodPlan` in `helixinfrarg`) were decommissioned as part of a CloudFit orphaned-resource cleanup (AzDO WI 10508). The panel's data target is **unaffected** — it queries the `dotnet-eng` App Insights component. Only the convenience portal link in the panel's `links` array still pointed at the now-deleted `helixview-prod` site, so it was a dead link.

## Change
- `links` array for the panel is now empty (dead link removed). No functional/data change to the dashboard.

JSON validated as well-formed; no remaining references to `helixview-prod`.