### PR TITLE
Remove arcade-validation from Build Monitor

### DIFF
--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
@@ -40,12 +40,6 @@
       "Builds": [
         {
           "Project": "internal",
-          "DefinitionPath": "\\dotnet\\arcade-validation\\dotnet-arcade-validation-official",
-          "Branches": [ "main" ],
-          "IssuesId": "dotnet-dnceng-build-failed"
-        },
-        {
-          "Project": "internal",
           "DefinitionPath": "\\dotnet\\arcade-services\\arcade-services-internal-ci",
           "Branches": [ "main" ],
           "IssuesId": "dotnet-arcade-services"
@@ -212,12 +206,6 @@
       ]
     },
     "Issues": [
-      {
-        "Id": "dotnet-dnceng-build-failed",
-        "Owner": "dotnet",
-        "Name": "dnceng",
-        "Labels": [ "Build Failed" ]
-      },
       {
         "Id": "dotnet-dnceng-ops",
         "Owner": "dotnet",


### PR DESCRIPTION
## What

Removes the `dotnet-arcade-validation-official` (main) build from the DotNet.Status.Web **Build Monitor**, plus the now-orphaned `dotnet-dnceng-build-failed` Issues target (arcade-validation was its only consumer).

## Why

The Arcade promotion gate for **main** moved in-repo to the `PromoteToLatest` stage (dotnet/arcade#17046), so the arcade-validation pipeline's main branch no longer needs Build Monitor coverage. It has been generating stale build-failure issues in dotnet/dnceng (e.g. #6641, which was closed as stale during FR/Ops triage).

## Scope / safety

- Only the `main` branch of `dotnet-arcade-validation-official` was monitored here, so this is scoped correctly.
- **Release branches still use dotnet/arcade-validation** (per dotnet/arcade#17046), so the pipeline, the internal `arcade-validation` repo, the `/collect/arcade-validation` telemetry endpoint, and the helix-machines subscription entries must remain until all serviced release branches migrate.
- Broader decommissioning (pipelines, monitoring, internal repos) is tracked in AzDO **WI 11920**.

## Validation

- JSON re-validated (parses cleanly); no remaining `arcade-validation` or `dotnet-dnceng-build-failed` references in `settings.json`.