### PR TITLE
Fix Grafana Azure Monitor datasource managed identity clientId

### DIFF
--- a/src/Monitoring/Monitoring.DncEng/datasource/Production/Azure Monitor.datasource.json
+++ b/src/Monitoring/Monitoring.DncEng/datasource/Production/Azure Monitor.datasource.json
@@ -14,9 +14,9 @@
   "isDefault": false,
   "jsonData": {
     "azureAuthType": "msi",
-    "clientId": "a2541735-8225-40af-9c8a-2ae233203739",
+    "clientId": "327cb9dd-8826-4310-8a8c-7ae6c1604fa2",
     "cloudName": "azuremonitor",
-    "logAnalyticsClientId": "a2541735-8225-40af-9c8a-2ae233203739",
+    "logAnalyticsClientId": "327cb9dd-8826-4310-8a8c-7ae6c1604fa2",
     "logAnalyticsTenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
     "subscriptionId": "68672ab8-de0c-40f1-8d1b-ffb20bd62c0f",
     "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"

--- a/src/Monitoring/Monitoring.DncEng/datasource/Staging/Azure Monitor.datasource.json
+++ b/src/Monitoring/Monitoring.DncEng/datasource/Staging/Azure Monitor.datasource.json
@@ -14,9 +14,9 @@
   "isDefault": false,
   "jsonData": {
     "azureAuthType": "msi",
-    "clientId": "a2541735-8225-40af-9c8a-2ae233203739",
+    "clientId": "ad02852f-49fa-4818-895f-8ac5a851274c",
     "cloudName": "azuremonitor",
-    "logAnalyticsClientId": "a2541735-8225-40af-9c8a-2ae233203739",
+    "logAnalyticsClientId": "ad02852f-49fa-4818-895f-8ac5a851274c",
     "logAnalyticsTenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
     "subscriptionId": "cab65fc3-d077-467d-931f-3932eabf36d3",
     "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"


### PR DESCRIPTION
## Summary

The Grafana Azure Monitor datasource (uid `F2XodEi7z`) hard-coded a managed identity `clientId`/`logAnalyticsClientId` of `a2541735-8225-40af-9c8a-2ae233203739`, which **does not resolve to any identity in the tenant** (verified: `az ad sp show` / `az ad app show` both return "resource does not exist").

The datasource JSON is published verbatim to the live workspace by the Monitoring SDK (`DeployPublisher.PostDatasourcesAsync` — only vault secrets are token-replaced), so the stale `clientId` is the live config.

This points the datasource at the **actual Azure Managed Grafana user-assigned managed identity** provisioned by `eng/azure-managed-grafana.bicep` and granted Monitoring Reader on the Helix / HelixStaging subscriptions by `eng/provision-grafana.yaml`:

| Environment | Identity | clientId |
|-------------|----------|----------|
| Production | `dnceng-managed-grafana` | `327cb9dd-8826-4310-8a8c-7ae6c1604fa2` |
| Staging | `dnceng-managed-grafana-staging` | `ad02852f-49fa-4818-895f-8ac5a851274c` |

Both values verified live via Azure Resource Graph against the `monitoring-managed` RG in sub `a4fc5514-...`.

## Impact

Enables the VMSS image name/version dashboard and image-model-drift alerting to read VMSS control-plane properties for the Helix and HelixStaging subscriptions through this datasource.

## Verification after deploy

Confirm ARG returns non-empty `properties` for VMSS in the Helix and HelixStaging subscriptions through the datasource once the DeployGrafana stage republishes it.

Fixes AB#11591
