### PR TITLE
[Rollout] Production rollout, 2026-07-29

### DIFF
--- a/.vault-config/dotneteng-status-local.yaml
+++ b/.vault-config/dotneteng-status-local.yaml
@@ -19,11 +19,6 @@ secrets:
       hasWebhookSecret: true
       hasOAuthSecret: true
 
-  grafana-api-token:
-    type: azure-managed-grafana-api-key
-    parameters:
-      environment: dotnet-eng-grafana-staging.westus2.cloudapp.azure.com
-
   # Shared secret for Grafana webhook contact point Basic Auth
   grafana-webhook-secret:
     type: text

--- a/.vault-config/dotneteng-status-prod.yaml
+++ b/.vault-config/dotneteng-status-prod.yaml
@@ -19,12 +19,6 @@ keys:
 importSecretsFrom: shared/dotneteng-status-secrets.yaml
 
 secrets:
-  # Grafana API key with admin privileges
-  grafana-api-token:
-    type: azure-managed-grafana-api-key
-    parameters:
-      environment: dotnet-eng-grafana.westus2.cloudapp.azure.com
-
   # Shared secret for Grafana webhook contact point Basic Auth
   grafana-webhook-secret:
     type: text

--- a/.vault-config/dotneteng-status-staging.yaml
+++ b/.vault-config/dotneteng-status-staging.yaml
@@ -19,12 +19,6 @@ keys:
 importSecretsFrom: shared/dotneteng-status-secrets.yaml
 
 secrets:
-  # Grafana API key with admin privileges
-  grafana-api-token:
-    type: azure-managed-grafana-api-key
-    parameters:
-      environment: dotnet-eng-grafana-staging.westus2.cloudapp.azure.com
-
   # Shared secret for Grafana webhook contact point Basic Auth
   grafana-webhook-secret:
     type: text

--- a/src/DotNet.Status.Web/DotNet.Status.Web.Tests/AnnotationsControllerTests.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web.Tests/AnnotationsControllerTests.cs
@@ -122,7 +122,7 @@ public class AnnotationsControllerTests
                 services.AddControllers()
                     .AddApplicationPart(typeof(AnnotationsController).Assembly);
 
-                services.Configure<GrafanaOptions>(options =>
+                services.Configure<DeploymentTableOptions>(options =>
                 {
                     options.TableUri = "https://127.0.0.1:10002/devstoreaccount1/deployments";
                 });

--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Development.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Development.json
@@ -49,7 +49,7 @@
     "StorageAccountConnectionString": "",
     "KeyIdentifier": ""
   },
-  "Grafana": {
+  "Deployments": {
     "TableUri": ""
   },
   "Kusto": {

--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Production.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Production.json
@@ -23,8 +23,7 @@
   "AzureTableTokenStore": {
     "TableUri": "https://dotnetengstatusprod.table.core.windows.net"
   },
-  "Grafana": {
-    "BaseUrl": "https://dotnet-eng-grafana.westus2.cloudapp.azure.com",
+  "Deployments": {
     "TableUri": "https://dotnetengstatusprod.table.core.windows.net"
   },
   "Kusto": {

--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Staging.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.Staging.json
@@ -25,7 +25,7 @@
   "AzureTableTokenStore": {
     "TableUri": "https://dotnetengstatusstaging.table.core.windows.net"
   },
-  "Grafana": {
+  "Deployments": {
     "TableUri": "https://dotnetengstatusstaging.table.core.windows.net"
   },
   "Kusto": {

--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
@@ -300,10 +300,10 @@
   "AzureTableTokenStore": {
     "TableName": "tokens"
   },
+  "Deployments": {
+    "TableName": "deployments"
+  },
   "Grafana": {
-    "BaseUrl": "https://dotnet-eng-grafana-staging.westus2.cloudapp.azure.com",
-    "ApiToken": "[vault(grafana-api-token)]",
-    "TableName": "deployments",
     "WebhookSecret": "[vault(grafana-webhook-secret)]"
   },
   "WebHooks": {

--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
@@ -40,12 +40,6 @@
       "Builds": [
         {
           "Project": "internal",
-          "DefinitionPath": "\\dotnet\\arcade-validation\\dotnet-arcade-validation-official",
-          "Branches": [ "main" ],
-          "IssuesId": "dotnet-dnceng-build-failed"
-        },
-        {
-          "Project": "internal",
           "DefinitionPath": "\\dotnet\\arcade-services\\arcade-services-internal-ci",
           "Branches": [ "main" ],
           "IssuesId": "dotnet-arcade-services"
@@ -212,12 +206,6 @@
       ]
     },
     "Issues": [
-      {
-        "Id": "dotnet-dnceng-build-failed",
-        "Owner": "dotnet",
-        "Name": "dnceng",
-        "Labels": [ "Build Failed" ]
-      },
       {
         "Id": "dotnet-dnceng-ops",
         "Owner": "dotnet",

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/AnnotationsController.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/AnnotationsController.cs
@@ -28,12 +28,12 @@ public class AnnotationsController : ControllerBase
 {
     private const int _maximumServerCount = 10; // Safety limit on query complexity
     private readonly ILogger<AnnotationsController> _logger;
-    private readonly IOptionsMonitor<GrafanaOptions> _options;
+    private readonly IOptionsMonitor<DeploymentTableOptions> _options;
     private readonly IHostEnvironment _env;
 
     public AnnotationsController(
         ILogger<AnnotationsController> logger,
-        IOptionsMonitor<GrafanaOptions> options,
+        IOptionsMonitor<DeploymentTableOptions> options,
         IHostEnvironment env)
     {
         _logger = logger;

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/DeploymentController.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/DeploymentController.cs
@@ -4,25 +4,15 @@
 
 using Azure;
 using System;
-using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
-using System.IO;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Azure.Data.Tables;
 using DotNet.Status.Web.Options;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.DotNet.Services.Utility;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using StatusWebAnnotationEntity = DotNet.Status.Web.Models.AnnotationEntity;
-using Microsoft.WindowsAzure.Storage.Table;
 using Azure.Identity;
 
 namespace DotNet.Status.Web.Controllers;
@@ -32,18 +22,15 @@ namespace DotNet.Status.Web.Controllers;
 public class DeploymentController : ControllerBase
 {
     private readonly IHostEnvironment _env;
-    private readonly ExponentialRetry _retry;
-    private readonly IOptionsMonitor<GrafanaOptions> _grafanaOptions;
+    private readonly IOptionsMonitor<DeploymentTableOptions> _deploymentTableOptions;
     private readonly ILogger<DeploymentController> _logger;
 
     public DeploymentController(
-        ExponentialRetry retry,
-        IOptionsMonitor<GrafanaOptions> grafanaOptions,
+        IOptionsMonitor<DeploymentTableOptions> deploymentTableOptions,
         ILogger<DeploymentController> logger,
         IHostEnvironment env)
     {
-        _retry = retry;
-        _grafanaOptions = grafanaOptions;
+        _deploymentTableOptions = deploymentTableOptions;
         _logger = logger;
         _env = env;
     }
@@ -52,47 +39,24 @@ public class DeploymentController : ControllerBase
     public async Task<IActionResult> MarkStart([Required] string service, [Required] string id)
     {
         _logger.LogInformation("Recording start of deployment of '{service}' with id '{id}'", service, id);
-        NewGrafanaAnnotationRequest content = new NewGrafanaAnnotationRequest
-        {
-            Text = $"Deployment of {service}",
-            Tags = new[] {"deploy", $"deploy-{service}", service},
-            Time = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-        };
-            
-        NewGrafanaAnnotationResponse annotation;
-        using (var client = new HttpClient(new HttpClientHandler() { CheckCertificateRevocationList = true }))
-        {
-            annotation = await _retry.RetryAsync(async () =>
-                {
-                    GrafanaOptions grafanaOptions = _grafanaOptions.CurrentValue;
-                    _logger.LogInformation("Creating annotation to {url}", grafanaOptions.BaseUrl);
-                    using (var request = new HttpRequestMessage(HttpMethod.Post,
-                               $"{grafanaOptions.BaseUrl}/api/annotations"))
-                    {
-                        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                        request.Headers.Authorization =
-                            new AuthenticationHeaderValue("Bearer", grafanaOptions.ApiToken);
-                        request.Content = CreateObjectContent(content);
 
-                        using (HttpResponseMessage response = await client.SendAsync(request, CancellationToken.None))
-                        {
-                            _logger.LogTrace("Response from grafana {responseCode} {reason}", response.StatusCode, response.ReasonPhrase);
-                            response.EnsureSuccessStatusCode();
-                            return await ReadObjectContent<NewGrafanaAnnotationResponse>(response.Content);
-                        }
-                    }
-                },
-                e => _logger.LogWarning(e, "Failed to send new annotation"),
-                e => true
-            );
+        // Recording a deployment annotation is best-effort telemetry and must never fail the calling
+        // deployment pipeline. The annotation is written to Azure Table storage, which Grafana reads
+        // directly; any failure is logged and swallowed so the endpoint returns success instead of a 500.
+        try
+        {
+            TableClient table = await GetCloudTable();
+            await table.UpsertEntityAsync(new StatusWebAnnotationEntity(service, id)
+            {
+                Started = DateTimeOffset.UtcNow,
+                ETag = new Azure.ETag("*")
+            });
         }
-        _logger.LogInformation("Created annotation {annotationId}, inserting into table", annotation.Id);
-
-        TableClient table = await GetCloudTable();
-        await table.UpsertEntityAsync(new DotNet.Status.Web.Models.AnnotationEntity(service, id, annotation.Id)
+        catch (Exception ex)
         {
-            ETag = new Azure.ETag("*")
-        });
+            _logger.LogError(ex, "Failed to record start of deployment of '{service}' with id '{id}'", service, id);
+        }
+
         return NoContent();
     }
 
@@ -100,51 +64,33 @@ public class DeploymentController : ControllerBase
     public async Task<IActionResult> MarkEnd([Required] string service, [Required] string id)
     {
         _logger.LogInformation("Recording end of deployment of '{service}' with id '{id}'", service, id);
-        TableClient table = await GetCloudTable();
-        _logger.LogInformation("Looking for existing deployment");
-        var getResult = await table.GetEntityIfExistsAsync<StatusWebAnnotationEntity>(service, id);
-        _logger.LogTrace("Table response code {responseCode}", getResult.GetRawResponse().Status);
-        if (!getResult.HasValue)
+
+        // As with MarkStart, recording the end of a deployment is best-effort telemetry written to
+        // Azure Table storage and must never fail the calling deployment pipeline. Any failure is
+        // logged and swallowed.
+        try
         {
-            return NotFound();
+            TableClient table = await GetCloudTable();
+            _logger.LogInformation("Looking for existing deployment");
+            var getResult = await table.GetEntityIfExistsAsync<StatusWebAnnotationEntity>(service, id);
+            _logger.LogTrace("Table response code {responseCode}", getResult.GetRawResponse().Status);
+            if (!getResult.HasValue)
+            {
+                _logger.LogWarning("No deployment start record found for '{service}' with id '{id}'; nothing to mark as ended", service, id);
+                return NoContent();
+            }
+
+            var annotation = getResult.Value;
+
+            _logger.LogTrace("Updating end time of deployment...");
+            annotation.Ended = DateTimeOffset.UtcNow;
+
+            var updateResult = await table.UpdateEntityAsync(annotation, annotation.ETag, TableUpdateMode.Replace);
+            _logger.LogInformation("Update response code {responseCode}", updateResult.Status);
         }
-
-        var annotation = getResult.Value;
-
-        _logger.LogTrace("Updating end time of deployment...");
-        annotation.Ended = DateTimeOffset.UtcNow;
-       
-        var updateResult = await table.UpdateEntityAsync(annotation, annotation.ETag, TableUpdateMode.Replace);
-        _logger.LogInformation("Update response code {responseCode}", updateResult.Status);
-            
-        var content = new NewGrafanaAnnotationRequest
+        catch (Exception ex)
         {
-            TimeEnd = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-        };
-
-        using (var client = new HttpClient(new HttpClientHandler() { CheckCertificateRevocationList = true }))
-        {
-            await _retry.RetryAsync(async () =>
-                {
-                    GrafanaOptions grafanaOptions = _grafanaOptions.CurrentValue;
-                    _logger.LogInformation("Updating annotation {annotationId} to {url}", annotation.GrafanaAnnotationId, grafanaOptions.BaseUrl);
-                    using (var request = new HttpRequestMessage(HttpMethod.Patch,
-                               $"{grafanaOptions.BaseUrl}/api/annotations/{annotation.GrafanaAnnotationId}"))
-                    {
-                        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                        request.Headers.Authorization =
-                            new AuthenticationHeaderValue("Bearer", grafanaOptions.ApiToken);
-                        request.Content = CreateObjectContent(content);
-                        using (HttpResponseMessage response = await client.SendAsync(request, CancellationToken.None))
-                        {
-                            _logger.LogTrace("Response from grafana {responseCode} {reason}", response.StatusCode, response.ReasonPhrase);
-                            response.EnsureSuccessStatusCode();
-                        }
-                    }
-                },
-                e => _logger.LogWarning(e, "Failed to send new annotation"),
-                e => true
-            );
+            _logger.LogError(ex, "Failed to record end of deployment of '{service}' with id '{id}'", service, id);
         }
 
         return NoContent();
@@ -153,7 +99,7 @@ public class DeploymentController : ControllerBase
     private async Task<TableClient> GetCloudTable()
     {
         TableClient table;
-        GrafanaOptions options = _grafanaOptions.CurrentValue;
+        DeploymentTableOptions options = _deploymentTableOptions.CurrentValue;
         if (_env.IsDevelopment())
         {
             table = new TableClient("UseDevelopmentStorage=true", options.TableName);
@@ -165,48 +111,4 @@ public class DeploymentController : ControllerBase
         }
         return table;
     }
-
-    private static StringContent CreateObjectContent(object content)
-    {
-        StringWriter writer = new StringWriter();
-        s_grafanaSerializer.Serialize(writer, content);
-        return new StringContent(writer.ToString(), Encoding.UTF8, "application/json");
-    }
-
-    private static async Task<T> ReadObjectContent<T>(HttpContent content)
-    {
-        using (var streamReader = new StreamReader(await content.ReadAsStreamAsync()))
-        using (var jsonReader = new JsonTextReader(streamReader))
-        {
-            return s_grafanaSerializer.Deserialize<T>(jsonReader);
-        }
-    }
-
-    private static readonly JsonSerializer s_grafanaSerializer = new JsonSerializer
-    {
-        ContractResolver = new CamelCasePropertyNamesContractResolver(),
-        Formatting = Formatting.None,
-    };
-}
-
-public class DeploymentStartRequest
-{
-    [Required]
-    public string Service { get; set; }
-}
-
-public class NewGrafanaAnnotationRequest
-{
-    public int? DashboardId { get; set; }
-    public int? PanelId { get; set; }
-    public long? Time { get; set; }
-    public long? TimeEnd { get; set; }
-    public string[] Tags { get; set; }
-    public string Text { get; set; }
-}
-
-public class NewGrafanaAnnotationResponse
-{
-    public string Message { get; set; }
-    public int Id { get; set; }
 }

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Options/DeploymentTableOptions.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Options/DeploymentTableOptions.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace DotNet.Status.Web.Options;
+
+// Storage coordinates for the deployment annotations table. The DeploymentController writes
+// deployment start/end records here and the AnnotationsController reads them back to serve
+// Grafana's annotation queries.
+public class DeploymentTableOptions
+{
+    public string TableUri { get; set; }
+    public string TableName { get; set; }
+}

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Options/GrafanaOptions.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Options/GrafanaOptions.cs
@@ -6,9 +6,5 @@ namespace DotNet.Status.Web.Options;
 
 public class GrafanaOptions
 {
-    public string BaseUrl { get; set; }
-    public string ApiToken { get; set; }
-    public string TableUri { get; set; }
-    public string TableName { get; set; }
     public string WebhookSecret { get; set; }
 }

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Startup.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Startup.cs
@@ -92,6 +92,7 @@ public class Startup
         services.Configure<TeamMentionForwardingOptions>(Configuration.GetSection("IssueMentionForwarding"));
         services.Configure<GitHubConnectionOptions>(Configuration.GetSection("GitHub"));
         services.Configure<GrafanaOptions>(Configuration.GetSection("Grafana"));
+        services.Configure<DeploymentTableOptions>(Configuration.GetSection("Deployments"));
         services.Configure<AzureDevOpsAlertOptions>(Configuration.GetSection("AzureDevOpsAlert"));
         services.Configure<AnnotationsOptions>(Configuration.GetSection("Annotations"));
         services.Configure<GitHubTokenProviderOptions>(Configuration.GetSection("GitHubAppAuth"));

--- a/src/Monitoring/Monitoring.DncEng/dashboard/dnceng/serviceAvailability.dashboard.json
+++ b/src/Monitoring/Monitoring.DncEng/dashboard/dnceng/serviceAvailability.dashboard.json
@@ -2902,13 +2902,7 @@
             "y": 50
           },
           "id": 19,
-          "links": [
-            {
-              "targetBlank": true,
-              "title": "Azure Portal: Average Response Time",
-              "url": "https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/blade/Microsoft_Azure_MonitoringAz/MetricsV4/Referer/MetricsExplorer/ResourceId/%2Fsubscriptions%2F68672ab8-de0c-40f1-8d1b-ffb20bd62c0f%2FresourceGroups%2Fhelixinfrarg%2Fproviders%2FMicrosoft.Web%2Fsites%2Fhelixview-prod/TimeContext/%7B%22relative%22%3A%7B%22duration%22%3A2592000000%7D%2C%22showUTCTime%22%3Afalse%2C%22grain%22%3A1%7D/ChartDefinition/%7B%22v2charts%22%3A%5B%7B%22metrics%22%3A%5B%7B%22resourceMetadata%22%3A%7B%22id%22%3A%22%2Fsubscriptions%2F68672ab8-de0c-40f1-8d1b-ffb20bd62c0f%2FresourceGroups%2Fhelixinfrarg%2Fproviders%2FMicrosoft.Web%2Fsites%2Fhelixview-prod%22%7D%2C%22name%22%3A%22AverageResponseTime%22%2C%22aggregationType%22%3A4%2C%22namespace%22%3A%22microsoft.web%2Fsites%22%2C%22metricVisualization%22%3A%7B%22displayName%22%3A%22Average%20Response%20Time%22%2C%22resourceDisplayName%22%3A%22helixview-prod%22%7D%7D%5D%2C%22title%22%3A%22Average%20Response%20Time%22%2C%22titleKind%22%3A2%2C%22visualization%22%3A%7B%22chartType%22%3A2%2C%22legendVisualization%22%3A%7B%22isVisible%22%3Atrue%2C%22position%22%3A2%2C%22hideSubtitle%22%3Afalse%7D%2C%22axisVisualization%22%3A%7B%22x%22%3A%7B%22isVisible%22%3Atrue%2C%22axisType%22%3A2%7D%2C%22y%22%3A%7B%22isVisible%22%3Atrue%2C%22axisType%22%3A1%7D%7D%7D%7D%5D%7D"
-            }
-          ],
+          "links": [],
           "options": {
             "legend": {
               "calcs": [

--- a/src/Monitoring/Monitoring.DncEng/dashboard/general/home.dashboard.json
+++ b/src/Monitoring/Monitoring.DncEng/dashboard/general/home.dashboard.json
@@ -284,6 +284,7 @@
           "visible": true
         }
       ],
+      "description": "Time series graph of Build Pool work item waiting times. Two series are plotted in minutes per day: Percentile95 (95th percentile) and Percentile50 (median). A red threshold line marks 30 minutes, above which waiting times are considered too high. An accessible, screen-reader navigable data table with the same values is provided in the \"Work Items Waiting Time (Build Pools) - Accessible Data Table\" panel below (MAS 1.3.1 - Info and Relationships).",
       "title": "Work Items Waiting Time (Build Pools)",
       "type": "timeseries"
     },
@@ -490,6 +491,7 @@
           "visible": true
         }
       ],
+      "description": "Time series graph of Test Queue work item waiting times. Two series are plotted in minutes per day: Percentile95 (95th percentile) and Percentile50 (median). A red threshold line marks 35 minutes, above which waiting times are considered too high. An accessible, screen-reader navigable data table with the same values is provided in the \"Work Items Waiting Time (Test Queues) - Accessible Data Table\" panel below (MAS 1.3.1 - Info and Relationships).",
       "title": "Work Items Waiting Time (Test Queues)",
       "type": "timeseries"
     },
@@ -628,6 +630,172 @@
       ],
       "title": "Number of Crashes in Helix",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "OlcfOPi7z"
+      },
+      "description": "Accessible data table equivalent of the \"Work Items Waiting Time (Build Pools)\" time series graph. Presents the same data as a screen-reader navigable table (MAS 1.3.1 - Info and Relationships): the 95th percentile (Percentile95) and median 50th percentile (Percentile50) of Build Pool work item waiting times, in minutes, per day. Values above the 30 minute threshold are considered too high.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "inspect": false
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#767676",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 30
+              }
+            ]
+          },
+          "unit": "m"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 7,
+        "x": 0,
+        "y": 26
+      },
+      "id": 12,
+      "options": {
+        "footer": {
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "database": "engineeringdata",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "OlcfOPi7z"
+          },
+          "query": "WorkItems \n| where  $__timeFilter(Queued)\n| project QueueName = tolower(QueueName), duration = datetime_diff('second', Started, Queued), Queued\n| where QueueName !contains \"osx\" and QueueName !contains \"perf\" and QueueName !contains \"arm\" and QueueName !contains \"arcade\" and QueueName !contains \"xaml\" and QueueName !contains \"appcompat\"\n| where QueueName contains \"buildpool\"\n| summarize Percentile95 = percentile(duration, 95) / 60 by bin(Queued, 1d)\n| order by Queued asc ",
+          "querySource": "raw",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        },
+        {
+          "database": "engineeringdata",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "OlcfOPi7z"
+          },
+          "hide": false,
+          "query": "WorkItems \n| where  $__timeFilter(Queued)\n| project QueueName = tolower(QueueName), duration = datetime_diff('second', Started, Queued), Queued\n| where QueueName !contains \"osx\" and QueueName !contains \"perf\" and QueueName !contains \"arm\" and QueueName !contains \"arcade\" and QueueName !contains \"xaml\" and QueueName !contains \"appcompat\"\n| where QueueName contains \"buildpool\"\n| summarize Percentile50 = percentile(duration, 50) / 60 by bin(Queued, 1d)\n| order by Queued asc ",
+          "querySource": "raw",
+          "rawMode": true,
+          "refId": "B",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Work Items Waiting Time (Build Pools) - Accessible Data Table",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana-azure-data-explorer-datasource",
+        "uid": "OlcfOPi7z"
+      },
+      "description": "Accessible data table equivalent of the \"Work Items Waiting Time (Test Queues)\" time series graph. Presents the same data as a screen-reader navigable table (MAS 1.3.1 - Info and Relationships): the 95th percentile (Percentile95) and median 50th percentile (Percentile50) of Test Queue work item waiting times, in minutes, per day. Values above the 35 minute threshold are considered too high.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "inspect": false
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#767676",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 35
+              }
+            ]
+          },
+          "unit": "m"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 7,
+        "x": 7,
+        "y": 26
+      },
+      "id": 13,
+      "options": {
+        "footer": {
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "database": "engineeringdata",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "OlcfOPi7z"
+          },
+          "query": "WorkItems \n| where  $__timeFilter(Queued)\n| project QueueName = tolower(QueueName), duration = datetime_diff('second', Started, Queued), Queued\n| where QueueName !contains \"osx\" and QueueName !contains \"perf\" and QueueName !contains \"arm\" and QueueName !contains \"arcade\" and QueueName !contains \"xaml\" and QueueName !contains \"appcompat\" and QueueName !contains \".tof\"\n| where QueueName !contains \"buildpool\"\n| summarize Percentile95 = percentile(duration, 95) / 60 by bin(Queued, 1d)\n| order by Queued asc ",
+          "querySource": "raw",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "table"
+        },
+        {
+          "database": "engineeringdata",
+          "datasource": {
+            "type": "grafana-azure-data-explorer-datasource",
+            "uid": "OlcfOPi7z"
+          },
+          "hide": false,
+          "query": "WorkItems \n| where  $__timeFilter(Queued)\n| project QueueName = tolower(QueueName), duration = datetime_diff('second', Started, Queued), Queued\n| where QueueName !contains \"osx\" and QueueName !contains \"perf\" and QueueName !contains \"arm\" and QueueName !contains \"arcade\" and QueueName !contains \"xaml\" and QueueName !contains \"appcompat\"\n| where QueueName !contains \"buildpool\"\n| summarize Percentile50 = percentile(duration, 50) / 60 by bin(Queued, 1d)\n| order by Queued asc ",
+          "querySource": "raw",
+          "rawMode": true,
+          "refId": "B",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Work Items Waiting Time (Test Queues) - Accessible Data Table",
+      "type": "table"
     }
   ],
   "schemaVersion": 34,

--- a/src/Monitoring/Monitoring.DncEng/datasource/Production/Azure Monitor.datasource.json
+++ b/src/Monitoring/Monitoring.DncEng/datasource/Production/Azure Monitor.datasource.json
@@ -14,9 +14,9 @@
   "isDefault": false,
   "jsonData": {
     "azureAuthType": "msi",
-    "clientId": "a2541735-8225-40af-9c8a-2ae233203739",
+    "clientId": "327cb9dd-8826-4310-8a8c-7ae6c1604fa2",
     "cloudName": "azuremonitor",
-    "logAnalyticsClientId": "a2541735-8225-40af-9c8a-2ae233203739",
+    "logAnalyticsClientId": "327cb9dd-8826-4310-8a8c-7ae6c1604fa2",
     "logAnalyticsTenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
     "subscriptionId": "68672ab8-de0c-40f1-8d1b-ffb20bd62c0f",
     "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"

--- a/src/Monitoring/Monitoring.DncEng/datasource/Staging/Azure Monitor.datasource.json
+++ b/src/Monitoring/Monitoring.DncEng/datasource/Staging/Azure Monitor.datasource.json
@@ -14,9 +14,9 @@
   "isDefault": false,
   "jsonData": {
     "azureAuthType": "msi",
-    "clientId": "a2541735-8225-40af-9c8a-2ae233203739",
+    "clientId": "ad02852f-49fa-4818-895f-8ac5a851274c",
     "cloudName": "azuremonitor",
-    "logAnalyticsClientId": "a2541735-8225-40af-9c8a-2ae233203739",
+    "logAnalyticsClientId": "ad02852f-49fa-4818-895f-8ac5a851274c",
     "logAnalyticsTenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
     "subscriptionId": "cab65fc3-d077-467d-931f-3932eabf36d3",
     "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"


### PR DESCRIPTION
## Rollout for dotnet-dnceng

**Deployment date:** 2026-07-29
**Rollout branch:** `rollout/2026-07-29` @ `3b5ee0b3` (Chan Kok Tien's fork `v-ctiean/dnceng`)
**Merge strategy:** Merge commit (do NOT squash, do NOT rebase)

> Note: PR #6655 (`7b32baf8` "Remove arcade-validation telemetry endpoint") is **excluded** from this rollout window; the cutoff is `3b5ee0b3`.

### Included PRs (5)
- #6653 - Fix Grafana Azure Monitor datasource managed identity clientId (Missy Messa)
- #6652 - Remove arcade-validation from Build Monitor (Missy Messa)
- #6651 - Remove stale helixview-prod portal link from serviceAvailability dashboard (Missy Messa)
- #6650 - Add accessible data-table equivalents for Grafana home dashboard graphs (Missy Messa)
- #6643 - Make dotnet-eng-status deployment notifications best-effort (Missy Messa)
