### PR TITLE
Add alerting for stalled TimelineBuilds data ingestion (AzDO 10698)

### DIFF
--- a/src/Monitoring/Monitoring.DncEng/alertrules/Production/timeline-builds-ingestion-stalled.alert.json
+++ b/src/Monitoring/Monitoring.DncEng/alertrules/Production/timeline-builds-ingestion-stalled.alert.json
@@ -1,0 +1,113 @@
+{
+  "uid": "timeline-builds-ingestion-stalled",
+  "title": "TimelineBuilds Data Ingestion Stalled",
+  "condition": "C",
+  "data": [
+    {
+      "refId": "A",
+      "queryType": "",
+      "datasourceUid": "OlcfOPi7z",
+      "relativeTimeRange": {
+        "from": 21600,
+        "to": 0
+      },
+      "model": {
+        "database": "engineeringdata",
+        "datasource": {
+          "type": "grafana-azure-data-explorer-datasource",
+          "uid": "OlcfOPi7z"
+        },
+        "expression": {
+          "groupBy": {
+            "expressions": [],
+            "type": "and"
+          },
+          "reduce": {
+            "expressions": [],
+            "type": "and"
+          },
+          "where": {
+            "expressions": [],
+            "type": "and"
+          }
+        },
+        "query": "TimelineBuilds\n| where ingestion_time() > ago(6h)\n| summarize LastIngest = max(ingestion_time())\n| extend AgeMinutes = todouble(datetime_diff('minute', now(), LastIngest))\n| project AgeMinutes",
+        "querySource": "raw",
+        "rawMode": true,
+        "refId": "A",
+        "resultFormat": "table"
+      }
+    },
+    {
+      "refId": "B",
+      "queryType": "",
+      "datasourceUid": "-100",
+      "relativeTimeRange": {
+        "from": 21600,
+        "to": 0
+      },
+      "model": {
+        "datasource": {
+          "type": "__expr__",
+          "uid": "-100"
+        },
+        "expression": "A",
+        "reducer": "last",
+        "refId": "B",
+        "type": "reduce"
+      }
+    },
+    {
+      "refId": "C",
+      "queryType": "",
+      "datasourceUid": "-100",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                120
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "B"
+              ]
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "-100"
+        },
+        "expression": "B",
+        "refId": "C",
+        "type": "threshold"
+      }
+    }
+  ],
+  "noDataState": "Alerting",
+  "execErrState": "KeepLast",
+  "for": "10m",
+  "frequency": "5m",
+  "annotations": {
+    "description": "TimelineBuilds (AzureDevOpsTimeline) data ingestion has stalled: no new rows have been ingested into the engineeringdata TimelineBuilds table in over 2 hours. Normal cadence is roughly one batch per hour (observed max gap ~70 min). This usually means the Microsoft.DotNet.AzureDevOpsTimeline background service in the Helix cluster is failing to write data (e.g. auth/config/managed-identity or PAT issue). On 2026-04-01 this same pipeline stalled and went unnoticed for weeks due to the absence of this alert. See AzDO WI 10698."
+  },
+  "labels": {
+    "NotificationId": "timeline-builds-ingestion-stalled"
+  },
+  "folderUID": "dnceng",
+  "ruleGroup": "Data Ingestion Alerts",
+  "intervalMs": 300000,
+  "isPaused": false,
+  "notification_settings": {
+    "receiver": "Teams Alert",
+    "group_wait": "5m",
+    "repeat_interval": "4h"
+  }
+}

--- a/src/Monitoring/Monitoring.DncEng/alertrules/Staging/timeline-builds-ingestion-stalled.alert.json
+++ b/src/Monitoring/Monitoring.DncEng/alertrules/Staging/timeline-builds-ingestion-stalled.alert.json
@@ -1,0 +1,113 @@
+{
+  "uid": "timeline-builds-ingestion-stalled",
+  "title": "TimelineBuilds Data Ingestion Stalled",
+  "condition": "C",
+  "data": [
+    {
+      "refId": "A",
+      "queryType": "",
+      "datasourceUid": "OlcfOPi7z",
+      "relativeTimeRange": {
+        "from": 21600,
+        "to": 0
+      },
+      "model": {
+        "database": "engineeringdata",
+        "datasource": {
+          "type": "grafana-azure-data-explorer-datasource",
+          "uid": "OlcfOPi7z"
+        },
+        "expression": {
+          "groupBy": {
+            "expressions": [],
+            "type": "and"
+          },
+          "reduce": {
+            "expressions": [],
+            "type": "and"
+          },
+          "where": {
+            "expressions": [],
+            "type": "and"
+          }
+        },
+        "query": "TimelineBuilds\n| where ingestion_time() > ago(6h)\n| summarize LastIngest = max(ingestion_time())\n| extend AgeMinutes = todouble(datetime_diff('minute', now(), LastIngest))\n| project AgeMinutes",
+        "querySource": "raw",
+        "rawMode": true,
+        "refId": "A",
+        "resultFormat": "table"
+      }
+    },
+    {
+      "refId": "B",
+      "queryType": "",
+      "datasourceUid": "-100",
+      "relativeTimeRange": {
+        "from": 21600,
+        "to": 0
+      },
+      "model": {
+        "datasource": {
+          "type": "__expr__",
+          "uid": "-100"
+        },
+        "expression": "A",
+        "reducer": "last",
+        "refId": "B",
+        "type": "reduce"
+      }
+    },
+    {
+      "refId": "C",
+      "queryType": "",
+      "datasourceUid": "-100",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                120
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "B"
+              ]
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "-100"
+        },
+        "expression": "B",
+        "refId": "C",
+        "type": "threshold"
+      }
+    }
+  ],
+  "noDataState": "Alerting",
+  "execErrState": "KeepLast",
+  "for": "10m",
+  "frequency": "5m",
+  "annotations": {
+    "description": "TimelineBuilds (AzureDevOpsTimeline) data ingestion has stalled: no new rows have been ingested into the engineeringdata TimelineBuilds table in over 2 hours. Normal cadence is roughly one batch per hour (observed max gap ~70 min). This usually means the Microsoft.DotNet.AzureDevOpsTimeline background service in the Helix cluster is failing to write data (e.g. auth/config/managed-identity or PAT issue). On 2026-04-01 this same pipeline stalled and went unnoticed for weeks due to the absence of this alert. See AzDO WI 10698."
+  },
+  "labels": {
+    "NotificationId": "timeline-builds-ingestion-stalled"
+  },
+  "folderUID": "dnceng",
+  "ruleGroup": "Data Ingestion Alerts",
+  "intervalMs": 300000,
+  "isPaused": false,
+  "notification_settings": {
+    "receiver": "Teams Alert",
+    "group_wait": "5m",
+    "repeat_interval": "4h"
+  }
+}


### PR DESCRIPTION
## What
Adds a Grafana **data-freshness alert** — `TimelineBuilds Data Ingestion Stalled` — in both **Production** and **Staging**, captured in code under `src/Monitoring/Monitoring.DncEng/alertrules/` so it deploys through the normal monitoring pipeline (not hand-applied in Grafana).

Fixes the monitoring gap called out in **AzDO WI 10698**.

## Why
The `Microsoft.DotNet.AzureDevOpsTimeline` ingestion pipeline (which fills the `engineeringdata.TimelineBuilds` Kusto table) stalled silently on **2026-04-01** and went unnoticed for **weeks** because nothing monitored data freshness. The underlying outage was already fixed (dotnet/dnceng#6540/#6541); this PR adds the missing alerting so a future stall is caught in ~2 hours instead of weeks.

## How it works
- Query uses Kusto `ingestion_time()` (the table has no dedicated ingestion column) to compute minutes since the last ingested row.
- Fires when `AgeMinutes > 120`. Normal cadence is ~1 batch/hour (verified: 7-day P95 gap 61 min, **max gap 70 min**), so 120 min gives headroom without false positives.
- `noDataState = Alerting` so a **total** stall (no rows in the 6h window) also fires.
- Routed to the **`Teams Alert`** contact point (FR/Ops Teams channel) for actionable on-call notification.

## Verification (live, both clusters)
| Cluster (env) | Last ingest | Rows/24h |
|---|---|---|
| `engsrvprod` (Production) | ~5 min ago | 2,152 |
| `engdata` (Staging) | ~16 min ago | 2,120 |

Both ADX datasources (`OlcfOPi7z`) point at live TimelineBuilds tables, so both env alerts are valid and won't false-fire. Embedded query validated end-to-end (returns a single numeric `AgeMinutes`). JSON validated; mirrors the existing Kusto alertrule schema (e.g. `helix-autoscaler-service-stopped`, `work-items-waiting-time-test-queues`).

## Notes
- No path filter / service code changes — pure monitoring config.
- Threshold (120 min) and receiver (`Teams Alert`) are easy to tune if desired.

Closes AzDO WI 10698.
