### PR TITLE
Fix DotNetEng Status request failure noise

### DIFF
--- a/src/DotNet.Status.Web/DotNet.Status.Web.Tests/AzurePipelinesControllerAzDoTests.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web.Tests/AzurePipelinesControllerAzDoTests.cs
@@ -251,6 +251,8 @@ public class AzurePipelinesControllerAzDoTests
                         Project = "internal",
                         DefinitionPath = "\\test\\test-pipeline",
                         Branches = new[] { "main" },
+                        Assignee = "test-user",
+                        Notify = "@dotnet/prodconsvcs",
                         IssuesId = "github-target"
                     }
                 }
@@ -277,7 +279,9 @@ public class AzurePipelinesControllerAzDoTests
         var mockComments = new Mock<Octokit.IIssueCommentsClient>();
         mockGithubClient.SetupGet(m => m.Issue).Returns(mockIssues.Object);
         mockIssues.SetupGet(m => m.Comment).Returns(mockComments.Object);
+        Octokit.NewIssue createdIssue = null;
         mockIssues.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Octokit.NewIssue>()))
+            .Callback<string, string, Octokit.NewIssue>((_, _, issue) => createdIssue = issue)
             .Returns(Task.FromResult(new Octokit.Issue()));
 
         var mockFactory = new Mock<IGitHubApplicationClientFactory>();
@@ -304,6 +308,8 @@ public class AzurePipelinesControllerAzDoTests
 
         // Should create GitHub issue
         mockIssues.Verify(m => m.Create("dotnet", "dnceng", It.IsAny<Octokit.NewIssue>()), Times.Once);
+        Assert.That(createdIssue.Assignees, Does.Contain("test-user"));
+        Assert.That(createdIssue.Body, Does.Contain("cc @dotnet/prodconsvcs"));
     }
 
     [Test]

--- a/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/.config/settings.json
@@ -155,35 +155,35 @@
           "DefinitionPath": "\\dotnet\\arcade\\Maestro Build Promotion",
           "Branches": [ "main" ],
           "IssuesId": "dotnet-arcade-services",
-          "Assignee": "dotnet/prodconsvcs"
+          "Notify": "@dotnet/prodconsvcs"
         },
         {
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\installer\\installer-dotnet-dotnet-synchronization",
           "Branches": [ "main", "release/*" ],
           "IssuesId": "dotnet-dotnet-synchronization",
-          "Assignee": "dotnet/prodconsvcs"
+          "Notify": "@dotnet/prodconsvcs"
         },
         {
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\installer\\installer-dotnet-dotnet-synchronization-internal",
           "Branches": [ "main", "release/*", "internal/release/*" ],
           "IssuesId": "dotnet-dotnet-synchronization",
-          "Assignee": "dotnet/prodconsvcs"
+          "Notify": "@dotnet/prodconsvcs"
         },
         {
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\sdk\\sdk-dotnet-dotnet-synchronization",
           "Branches": [ "main", "release/*" ],
           "IssuesId": "dotnet-dotnet-synchronization",
-          "Assignee": "dotnet/prodconsvcs"
+          "Notify": "@dotnet/prodconsvcs"
         },
         {
           "Project": "internal",
           "DefinitionPath": "\\dotnet\\sdk\\sdk-dotnet-dotnet-synchronization-internal",
           "Branches": [ "main", "release/*", "internal/release/*" ],
           "IssuesId": "dotnet-dotnet-synchronization",
-          "Assignee": "dotnet/prodconsvcs"
+          "Notify": "@dotnet/prodconsvcs"
         },
         {
           "Project": "internal",

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/AzurePipelinesController.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/AzurePipelinesController.cs
@@ -383,6 +383,12 @@ public class AzurePipelinesController : ControllerBase
 
 {changesMessage}
 ";
+
+        if (!string.IsNullOrWhiteSpace(monitor.Notify))
+        {
+            body += $"\ncc {monitor.Notify.Trim()}\n";
+        }
+
         string issueTitlePrefix = $"Build failed: {build.Definition.Name}/{branchName} {prettyTags}";
 
         if (repo.UpdateExisting)

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Options/BuildMonitorOptions.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Options/BuildMonitorOptions.cs
@@ -21,6 +21,7 @@ public class BuildMonitorOptions
             public string DefinitionPath { get; set; }
             public string[] Branches { get; set; }
             public string Assignee { get; set; }
+            public string Notify { get; set; }
             public string[] Labels { get; set; }
             public string[] Tags { get; set; }
             public string IssuesId { get; set; }

--- a/src/Monitoring/Monitoring.DncEng/alertrules/Production/dotneteng-status-failed-requests.alert.json
+++ b/src/Monitoring/Monitoring.DncEng/alertrules/Production/dotneteng-status-failed-requests.alert.json
@@ -10,7 +10,7 @@
       "model": {
         "azureLogAnalytics": {
           "dashboardTime": true,
-          "query": "let r = requests | where $__timeFilter(timestamp);\nlet f = coalesce(toscalar(r | summarize min(timestamp)), ago(1d));\nlet t = coalesce(toscalar(r | summarize max(timestamp)), now());\nlet span=(t - f)/60;\nlet interval=case(span >= 1d, bin(span, 1d), span >= 1h, bin(span, 1h), 15m);\nlet intervalHours = interval / 1h;\nr\n| where success == false\n| make-series kind=nonempty valueCount=count() default=0 on timestamp in range(f, t, interval)\n| mv-expand timestamp to typeof(datetime), valueCount to typeof(double)\n| project timestamp, failuresCount=valueCount/intervalHours",
+          "query": "let r = requests | where $__timeFilter(timestamp);\nlet f = coalesce(toscalar(r | summarize min(timestamp)), ago(1d));\nlet t = coalesce(toscalar(r | summarize max(timestamp)), now());\nlet span=(t - f)/60;\nlet interval=case(span >= 1d, bin(span, 1d), span >= 1h, bin(span, 1h), 15m);\nlet intervalHours = interval / 1h;\nr\n| where toint(resultCode) >= 500\n| make-series kind=nonempty valueCount=count() default=0 on timestamp in range(f, t, interval)\n| mv-expand timestamp to typeof(datetime), valueCount to typeof(double)\n| project timestamp, failuresCount=valueCount/intervalHours",
           "resources": [
             "/subscriptions/68672ab8-de0c-40f1-8d1b-ffb20bd62c0f/resourceGroups/monitoring/providers/microsoft.insights/components/DotNetEng-Status-Prod"
           ],

--- a/src/Monitoring/Monitoring.DncEng/alertrules/Staging/dotneteng-status-failed-requests.alert.json
+++ b/src/Monitoring/Monitoring.DncEng/alertrules/Staging/dotneteng-status-failed-requests.alert.json
@@ -10,7 +10,7 @@
       "model": {
         "azureLogAnalytics": {
           "dashboardTime": true,
-          "query": "let r = requests | where $__timeFilter(timestamp);\nlet f = coalesce(toscalar(r | summarize min(timestamp)), ago(1d));\nlet t = coalesce(toscalar(r | summarize max(timestamp)), now());\nlet span=(t - f)/60;\nlet interval=case(span >= 1d, bin(span, 1d), span >= 1h, bin(span, 1h), 15m);\nlet intervalHours = interval / 1h;\nr\n| where success == false\n| make-series kind=nonempty valueCount=count() default=0 on timestamp in range(f, t, interval)\n| mv-expand timestamp to typeof(datetime), valueCount to typeof(double)\n| project timestamp, failuresCount=valueCount/intervalHours",
+          "query": "let r = requests | where $__timeFilter(timestamp);\nlet f = coalesce(toscalar(r | summarize min(timestamp)), ago(1d));\nlet t = coalesce(toscalar(r | summarize max(timestamp)), now());\nlet span=(t - f)/60;\nlet interval=case(span >= 1d, bin(span, 1d), span >= 1h, bin(span, 1h), 15m);\nlet intervalHours = interval / 1h;\nr\n| where toint(resultCode) >= 500\n| make-series kind=nonempty valueCount=count() default=0 on timestamp in range(f, t, interval)\n| mv-expand timestamp to typeof(datetime), valueCount to typeof(double)\n| project timestamp, failuresCount=valueCount/intervalHours",
           "resources": [
             "/subscriptions/68672ab8-de0c-40f1-8d1b-ffb20bd62c0f/resourceGroups/monitoring/providers/microsoft.insights/components/DotNetEng-Status-Prod"
           ],


### PR DESCRIPTION
## Summary
- route `dotnet/prodconsvcs` through a GitHub team mention instead of sending the team slug as an issue assignee
- preserve individual GitHub username assignment through the existing `Assignee` setting
- restrict DotNetEng Status failed-request alerts to HTTP 5xx responses so expected scanner-generated 4xx responses do not page

## Production evidence
App Insights showed 37 of the latest 38 `BuildComplete` failures came from Maestro Build Promotion. GitHub issue creation returned HTTP 422 because `dotnet/prodconsvcs` was placed in `NewIssue.Assignees`; GitHub only accepts individual usernames there.

The `/Status` and `/Index` entries were status-page rewrites for external probes such as `/mcp`, `/swagger`, `/.env`, and `/.git/config`, returning the expected 400/404 responses.

## Validation
- `AzurePipelinesController` tests: 13 passed
- `Monitoring.DncEng.proj`: build succeeded

Related: https://dev.azure.com/dnceng/internal/_workitems/edit/12002