### PR TITLE
Remove unused Publish-Build-Assets import

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,8 +76,6 @@ extends:
                   targetPath: $(Build.SourcesDirectory)\artifacts\bin\AzureDevOpsClient.PostDeploymentTests\$(_BuildConfig)\net8.0
                   artifactName: AzureDevOpsClient.PostDeploymentTests
             variables:
-            # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
-            - group: Publish-Build-Assets
             - _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
             - _BuildConfig: Release
             - _PublishType: blob


### PR DESCRIPTION
## Summary
- remove the direct `Publish-Build-Assets` variable-group import from dnceng CI
- remove the obsolete comment describing credentials that the pipeline does not consume

The expanded pipeline contains no references to any variable currently supplied by VG20, so no replacement variable group is required.

Tracking: https://dev.azure.com/dnceng/internal/_workitems/edit/12131