### PR TITLE
Persist Infinity plugin for Azure Managed Grafana

### DIFF
--- a/eng/deployment/azure-managed-grafana.bicep
+++ b/eng/deployment/azure-managed-grafana.bicep
@@ -177,6 +177,9 @@ resource grafanaWorkspace 'Microsoft.Dashboard/grafana@2023-09-01' = {
     grafanaIntegrations: {
       azureMonitorWorkspaceIntegrations: []
     }
+    grafanaPlugins: {
+      'yesoreyeram-infinity-datasource': {}
+    }
   }
 }
 


### PR DESCRIPTION
Persist the Infinity datasource plugin in the Azure Managed Grafana Bicep template for both staging and production workspaces.

## Why the plugin is required

The Helix Grafana configuration includes the `deployment-annotations-infinity` datasource, whose type is `yesoreyeram-infinity-datasource`. The `buildAnalysis`, `queues`, `historical`, and `serviceAvailability` dashboards use it to retrieve deployment markers from EngStatus and display those deployments alongside service and build telemetry.

Infinity is an optional Azure Managed Grafana plugin and is not installed automatically. Without it, the datasource can remain configured but cannot load: its health check fails and deployment annotations disappear from the dashboards. It also leaves the post-deployment smoke chronically red, obscuring genuine Grafana regressions.

Declaring the plugin in Bicep ensures both workspaces install and retain it whenever their infrastructure is created or updated.

Production was remediated live on 2026-08-19 and now passes the full Grafana smoke suite with 23 PASS, 0 FAIL, and 2 expected SKIP/WARN.

Related: AB#11938