### PR TITLE
Add GitHub webhook secret drift alert

### DIFF
--- a/src/Monitoring/Monitoring.DncEng/alertrules/Production/dotneteng-status-webhook-secret-drift.alert.json
+++ b/src/Monitoring/Monitoring.DncEng/alertrules/Production/dotneteng-status-webhook-secret-drift.alert.json
@@ -1,6 +1,6 @@
 {
   "uid": "dotneteng-status-webhook-secret-drift",
-  "title": "DotNetEng Status Webhook Secret Drift",
+  "title": "DotNetEng Status GitHub Webhook Secret Drift",
   "condition": "C",
   "data": [
     {
@@ -14,7 +14,7 @@
       "model": {
         "azureLogAnalytics": {
           "dashboardTime": true,
-          "query": "requests\n| where $__timeFilter(timestamp)\n| extend RequestUrl = tolower(tostring(url))\n| extend FailureType = case(\n    resultCode == \"400\" and RequestUrl contains \"/api/webhooks/incoming/github\", \"GitHub webhook secret mismatch\",\n    resultCode == \"401\" and RequestUrl contains \"/api/alert\", \"Grafana webhook secret mismatch\",\n    \"\")\n| where isnotempty(FailureType)\n| summarize Failures=count() by bin(timestamp, 5m), FailureType\n| order by timestamp asc",
+          "query": "requests\n| where $__timeFilter(timestamp)\n| extend RequestUrl = tolower(tostring(url))\n| where resultCode == \"400\" and RequestUrl contains \"/api/webhooks/incoming/github\"\n| summarize Failures=count() by bin(timestamp, 5m)\n| order by timestamp asc",
           "resources": [
             "/subscriptions/68672ab8-de0c-40f1-8d1b-ffb20bd62c0f/resourceGroups/monitoring/providers/microsoft.insights/components/DotNetEng-Status-Prod"
           ],
@@ -96,13 +96,13 @@
   "for": "5m",
   "frequency": "1m",
   "annotations": {
-    "description": "More than 20 inbound webhook authentication failures were recorded in the previous hour for {{ $labels.FailureType }}. This indicates likely sender-side secret drift. GitHub webhook failures are HTTP 400 responses from /api/webhooks/incoming/github; Grafana webhook failures are HTTP 401 responses from /api/alert. Investigate the paired secret locations documented in work item 11933 and use work item 10636 as the root-cause reference."
+    "description": "More than 20 GitHub webhook authentication failures were recorded in the previous hour. This indicates likely sender-side drift between the DotNetEng Status github-app-webhook-secret and the Dotnet Eng Status GitHub App webhook configuration. Investigate the paired locations documented in work item 11933 and use work item 10636 as the root-cause reference."
   },
   "labels": {
     "NotificationId": "c5f006b35ecf4f0ea970e26a8ab37f71"
   },
   "folderUID": "dnceng",
-  "ruleGroup": "DotNetEng Status Webhook Alerts",
+  "ruleGroup": "DotNetEng Status GitHub Webhook Alerts",
   "intervalMs": 60000,
   "isPaused": false,
   "notification_settings": {

--- a/src/Monitoring/Monitoring.DncEng/alertrules/Production/dotneteng-status-webhook-secret-drift.alert.json
+++ b/src/Monitoring/Monitoring.DncEng/alertrules/Production/dotneteng-status-webhook-secret-drift.alert.json
@@ -1,0 +1,113 @@
+{
+  "uid": "dotneteng-status-webhook-secret-drift",
+  "title": "DotNetEng Status Webhook Secret Drift",
+  "condition": "C",
+  "data": [
+    {
+      "refId": "A",
+      "queryType": "Azure Log Analytics",
+      "datasourceUid": "F2XodEi7z",
+      "relativeTimeRange": {
+        "from": 3600,
+        "to": 0
+      },
+      "model": {
+        "azureLogAnalytics": {
+          "dashboardTime": true,
+          "query": "requests\n| where $__timeFilter(timestamp)\n| extend RequestUrl = tolower(tostring(url))\n| extend FailureType = case(\n    resultCode == \"400\" and RequestUrl contains \"/api/webhooks/incoming/github\", \"GitHub webhook secret mismatch\",\n    resultCode == \"401\" and RequestUrl contains \"/api/alert\", \"Grafana webhook secret mismatch\",\n    \"\")\n| where isnotempty(FailureType)\n| summarize Failures=count() by bin(timestamp, 5m), FailureType\n| order by timestamp asc",
+          "resources": [
+            "/subscriptions/68672ab8-de0c-40f1-8d1b-ffb20bd62c0f/resourceGroups/monitoring/providers/microsoft.insights/components/DotNetEng-Status-Prod"
+          ],
+          "resultFormat": "time_series",
+          "workspace": "/subscriptions/68672ab8-de0c-40f1-8d1b-ffb20bd62c0f/resourceGroups/monitoring/providers/Microsoft.OperationalInsights/workspaces/dotneteng-status-prod-wus2"
+        },
+        "azureMonitor": {
+          "dimensionFilters": [],
+          "timeGrain": "auto"
+        },
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "F2XodEi7z"
+        },
+        "queryType": "Azure Log Analytics",
+        "refId": "A",
+        "subscription": "68672ab8-de0c-40f1-8d1b-ffb20bd62c0f",
+        "subscriptions": [
+          "68672ab8-de0c-40f1-8d1b-ffb20bd62c0f",
+          "cab65fc3-d077-467d-931f-3932eabf36d3"
+        ]
+      }
+    },
+    {
+      "refId": "B",
+      "queryType": "",
+      "datasourceUid": "-100",
+      "relativeTimeRange": {
+        "from": 3600,
+        "to": 0
+      },
+      "model": {
+        "datasource": {
+          "type": "__expr__",
+          "uid": "-100"
+        },
+        "expression": "A",
+        "reducer": "sum",
+        "refId": "B",
+        "type": "reduce"
+      }
+    },
+    {
+      "refId": "C",
+      "queryType": "",
+      "datasourceUid": "-100",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                20
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "B"
+              ]
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "-100"
+        },
+        "expression": "B",
+        "refId": "C",
+        "type": "threshold"
+      }
+    }
+  ],
+  "noDataState": "OK",
+  "execErrState": "KeepLast",
+  "for": "5m",
+  "frequency": "1m",
+  "annotations": {
+    "description": "More than 20 inbound webhook authentication failures were recorded in the previous hour for {{ $labels.FailureType }}. This indicates likely sender-side secret drift. GitHub webhook failures are HTTP 400 responses from /api/webhooks/incoming/github; Grafana webhook failures are HTTP 401 responses from /api/alert. Investigate the paired secret locations documented in work item 11933 and use work item 10636 as the root-cause reference."
+  },
+  "labels": {
+    "NotificationId": "c5f006b35ecf4f0ea970e26a8ab37f71"
+  },
+  "folderUID": "dnceng",
+  "ruleGroup": "DotNetEng Status Webhook Alerts",
+  "intervalMs": 60000,
+  "isPaused": false,
+  "notification_settings": {
+    "receiver": "Teams Alert",
+    "group_wait": "5m",
+    "repeat_interval": "4h"
+  }
+}

--- a/src/Monitoring/Monitoring.DncEng/alertrules/Staging/dotneteng-status-webhook-secret-drift.alert.json
+++ b/src/Monitoring/Monitoring.DncEng/alertrules/Staging/dotneteng-status-webhook-secret-drift.alert.json
@@ -1,0 +1,113 @@
+{
+  "uid": "dotneteng-status-webhook-secret-drift",
+  "title": "DotNetEng Status Webhook Secret Drift",
+  "condition": "C",
+  "data": [
+    {
+      "refId": "A",
+      "queryType": "Azure Log Analytics",
+      "datasourceUid": "F2XodEi7z",
+      "relativeTimeRange": {
+        "from": 3600,
+        "to": 0
+      },
+      "model": {
+        "azureLogAnalytics": {
+          "dashboardTime": true,
+          "query": "requests\n| where $__timeFilter(timestamp)\n| extend RequestUrl = tolower(tostring(url))\n| extend FailureType = case(\n    resultCode == \"400\" and RequestUrl contains \"/api/webhooks/incoming/github\", \"GitHub webhook secret mismatch\",\n    resultCode == \"401\" and RequestUrl contains \"/api/alert\", \"Grafana webhook secret mismatch\",\n    \"\")\n| where isnotempty(FailureType)\n| summarize Failures=count() by bin(timestamp, 5m), FailureType\n| order by timestamp asc",
+          "resources": [
+            "/subscriptions/cab65fc3-d077-467d-931f-3932eabf36d3/resourceGroups/monitoring/providers/microsoft.insights/components/DotNetEng-Status-Staging"
+          ],
+          "resultFormat": "time_series",
+          "workspace": "/subscriptions/cab65fc3-d077-467d-931f-3932eabf36d3/resourceGroups/monitoring/providers/Microsoft.OperationalInsights/workspaces/dotneteng-status-staging-wus2"
+        },
+        "azureMonitor": {
+          "dimensionFilters": [],
+          "timeGrain": "auto"
+        },
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "F2XodEi7z"
+        },
+        "queryType": "Azure Log Analytics",
+        "refId": "A",
+        "subscription": "cab65fc3-d077-467d-931f-3932eabf36d3",
+        "subscriptions": [
+          "68672ab8-de0c-40f1-8d1b-ffb20bd62c0f",
+          "cab65fc3-d077-467d-931f-3932eabf36d3"
+        ]
+      }
+    },
+    {
+      "refId": "B",
+      "queryType": "",
+      "datasourceUid": "-100",
+      "relativeTimeRange": {
+        "from": 3600,
+        "to": 0
+      },
+      "model": {
+        "datasource": {
+          "type": "__expr__",
+          "uid": "-100"
+        },
+        "expression": "A",
+        "reducer": "sum",
+        "refId": "B",
+        "type": "reduce"
+      }
+    },
+    {
+      "refId": "C",
+      "queryType": "",
+      "datasourceUid": "-100",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                20
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "B"
+              ]
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "-100"
+        },
+        "expression": "B",
+        "refId": "C",
+        "type": "threshold"
+      }
+    }
+  ],
+  "noDataState": "OK",
+  "execErrState": "KeepLast",
+  "for": "5m",
+  "frequency": "1m",
+  "annotations": {
+    "description": "More than 20 inbound webhook authentication failures were recorded in the previous hour for {{ $labels.FailureType }}. This indicates likely sender-side secret drift. GitHub webhook failures are HTTP 400 responses from /api/webhooks/incoming/github; Grafana webhook failures are HTTP 401 responses from /api/alert. Investigate the paired secret locations documented in work item 11933 and use work item 10636 as the root-cause reference."
+  },
+  "labels": {
+    "NotificationId": "c5f006b35ecf4f0ea970e26a8ab37f71"
+  },
+  "folderUID": "dnceng",
+  "ruleGroup": "DotNetEng Status Webhook Alerts",
+  "intervalMs": 60000,
+  "isPaused": false,
+  "notification_settings": {
+    "receiver": "Teams Alert",
+    "group_wait": "5m",
+    "repeat_interval": "4h"
+  }
+}

--- a/src/Monitoring/Monitoring.DncEng/alertrules/Staging/dotneteng-status-webhook-secret-drift.alert.json
+++ b/src/Monitoring/Monitoring.DncEng/alertrules/Staging/dotneteng-status-webhook-secret-drift.alert.json
@@ -1,6 +1,6 @@
 {
   "uid": "dotneteng-status-webhook-secret-drift",
-  "title": "DotNetEng Status Webhook Secret Drift",
+  "title": "DotNetEng Status GitHub Webhook Secret Drift",
   "condition": "C",
   "data": [
     {
@@ -14,7 +14,7 @@
       "model": {
         "azureLogAnalytics": {
           "dashboardTime": true,
-          "query": "requests\n| where $__timeFilter(timestamp)\n| extend RequestUrl = tolower(tostring(url))\n| extend FailureType = case(\n    resultCode == \"400\" and RequestUrl contains \"/api/webhooks/incoming/github\", \"GitHub webhook secret mismatch\",\n    resultCode == \"401\" and RequestUrl contains \"/api/alert\", \"Grafana webhook secret mismatch\",\n    \"\")\n| where isnotempty(FailureType)\n| summarize Failures=count() by bin(timestamp, 5m), FailureType\n| order by timestamp asc",
+          "query": "requests\n| where $__timeFilter(timestamp)\n| extend RequestUrl = tolower(tostring(url))\n| where resultCode == \"400\" and RequestUrl contains \"/api/webhooks/incoming/github\"\n| summarize Failures=count() by bin(timestamp, 5m)\n| order by timestamp asc",
           "resources": [
             "/subscriptions/cab65fc3-d077-467d-931f-3932eabf36d3/resourceGroups/monitoring/providers/microsoft.insights/components/DotNetEng-Status-Staging"
           ],
@@ -96,13 +96,13 @@
   "for": "5m",
   "frequency": "1m",
   "annotations": {
-    "description": "More than 20 inbound webhook authentication failures were recorded in the previous hour for {{ $labels.FailureType }}. This indicates likely sender-side secret drift. GitHub webhook failures are HTTP 400 responses from /api/webhooks/incoming/github; Grafana webhook failures are HTTP 401 responses from /api/alert. Investigate the paired secret locations documented in work item 11933 and use work item 10636 as the root-cause reference."
+    "description": "More than 20 GitHub webhook authentication failures were recorded in the previous hour. This indicates likely sender-side drift between the DotNetEng Status github-app-webhook-secret and the Dotnet Eng Status GitHub App webhook configuration. Investigate the paired locations documented in work item 11933 and use work item 10636 as the root-cause reference."
   },
   "labels": {
     "NotificationId": "c5f006b35ecf4f0ea970e26a8ab37f71"
   },
   "folderUID": "dnceng",
-  "ruleGroup": "DotNetEng Status Webhook Alerts",
+  "ruleGroup": "DotNetEng Status GitHub Webhook Alerts",
   "intervalMs": 60000,
   "isPaused": false,
   "notification_settings": {


### PR DESCRIPTION
## Summary
- add production and staging alerts for DotNetEng Status GitHub webhook-secret drift
- detect sustained HTTP 400 failures on `/api/webhooks/incoming/github`
- fire when failures exceed 20 in the trailing hour for five minutes
- route to Teams independently of the failing GitHub webhook

The Grafana `/api/alert` HTTP 401 signal was removed after the V1 outcome audit. That endpoint, its contact points, and its duplicate secrets are being retired under AB#12297 and AB#12004 rather than preserved with new monitoring.

## Validation
- monitoring project builds with 0 warnings and 0 errors
- production incident-hour datasource backtest returned 364 GitHub webhook failures
- current production and staging hour returned no matching series
- the existing alert UID is preserved so deployment updates the staged rule rather than orphaning it

Tracking: https://dnceng.visualstudio.com/internal/_workitems/edit/11933
Related retirement: https://dev.azure.com/dnceng/internal/_workitems/edit/12297

<!-- pr-stack -->
## PR stack

Merge these PRs from top to bottom in this table. After a parent merges, retarget the next PR to `main`.

| Order | PR | Change |
| --- | --- | --- |
| 1 | [#6701](https://github.com/dotnet/dnceng/pull/6701) | Fix Grafana dashboard retirement cleanup |
| 2 | [#6703](https://github.com/dotnet/dnceng/pull/6703) | Migrate Data Migration alerts to Grafana |
| 3 | [#6694](https://github.com/dotnet/dnceng/pull/6694) | Add GitHub webhook secret drift alert |
| 4 | [#6702](https://github.com/dotnet/dnceng/pull/6702) | Retire source.dot.net monitoring |
| 5 | [#6706](https://github.com/dotnet/dnceng/pull/6706) | Inventory V1 Grafana retirements in report-only mode |