### PR TITLE
Fix GitHub PAT prompt order

### DIFF
--- a/src/SecretManager/Microsoft.DncEng.SecretManager.Tests/GitHubAccessTokenTests.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager.Tests/GitHubAccessTokenTests.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
 using AwesomeAssertions;
 using Microsoft.DncEng.CommandLineLib;
 using Microsoft.DncEng.SecretManager.SecretTypes;
@@ -67,6 +71,73 @@ public class GitHubAccessTokenTests
 
         nextRotationOn.Should().BeAfter(now);
         nextRotationOn.Should().BeBefore(expiresOn);
+    }
+
+    [Test]
+    public async Task RotateValue_ShouldPromptForExpirationAfterLoginInformationAndBeforePat()
+    {
+        DateTimeOffset now = new DateTimeOffset(2026, 8, 24, 0, 0, 0, TimeSpan.Zero);
+        var interactions = new List<string>();
+        var console = new Mock<IConsole>();
+        console.SetupGet(c => c.IsInteractive).Returns(true);
+        console.Setup(c => c.ShouldWrite(It.IsAny<VerbosityLevel>())).Returns(true);
+        console.Setup(c => c.Write(It.IsAny<VerbosityLevel>(), It.IsAny<string>(), It.IsAny<ConsoleColor?>()))
+            .Callback((VerbosityLevel _, string message, ConsoleColor? _) =>
+            {
+                if (message.StartsWith("Please login to", StringComparison.Ordinal))
+                {
+                    interactions.Add("Login information");
+                }
+            });
+        console.Setup(c => c.ConfirmAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Callback((string _, string _) => interactions.Add("One-time password"))
+            .ReturnsAsync(false);
+        console.Setup(c => c.PromptAsync(It.IsAny<string>()))
+            .Returns((string message) =>
+            {
+                interactions.Add(message);
+                return Task.FromResult(message == "Enter expiration in days: "
+                    ? "14"
+                    : $"ghp_{new string('a', 36)}");
+            });
+
+        var clock = new Mock<ISystemClock>();
+        clock.SetupGet(c => c.UtcNow).Returns(now);
+
+        var storage = new Mock<StorageLocationType>();
+        storage.Setup(s => s.GetSecretValueAsync(It.IsAny<IDictionary<string, object>>(), "bot-password"))
+            .ReturnsAsync(CreateSecretValue("password"));
+        storage.Setup(s => s.GetSecretValueAsync(It.IsAny<IDictionary<string, object>>(), "bot-otp"))
+            .ReturnsAsync(CreateSecretValue("JBSWY3DPEHPK3PXP"));
+
+        var context = new RotationContext(
+            "token",
+            ImmutableDictionary<string, string>.Empty,
+            storage.Object.BindParameters(new Dictionary<string, object>()),
+            ImmutableDictionary<string, StorageLocationType.Bound>.Empty);
+        var parameters = new GitHubAccessToken.Parameters
+        {
+            GitHubBotAccountName = "bot-account",
+            GitHubBotAccountSecret = new SecretReference("bot"),
+        };
+        var token = new GitHubAccessToken(clock.Object, console.Object);
+
+        await token.RotateValues(parameters, context, CancellationToken.None);
+
+        interactions.Should().ContainInOrder(
+            "Login information",
+            "One-time password",
+            "Enter expiration in days: ",
+            "Enter PAT: ");
+    }
+
+    private static SecretValue CreateSecretValue(string value)
+    {
+        return new SecretValue(
+            value,
+            ImmutableDictionary<string, string>.Empty,
+            DateTimeOffset.MaxValue,
+            DateTimeOffset.MaxValue);
     }
 
     // Test helper class exposing the protected static members for testing.

--- a/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/GitHubAccessToken.cs
+++ b/src/SecretManager/Microsoft.DncEng.SecretManager/SecretTypes/GitHubAccessToken.cs
@@ -34,6 +34,14 @@ public class GitHubAccessToken : GitHubAccountInteractiveSecretType<GitHubAccess
             throw new HumanInterventionRequiredException($"User intervention required for creation or rotation of a GitHub access token.");
         }
 
+        const string helpUrl = "https://github.com/settings/tokens";
+
+        if (!string.IsNullOrEmpty(parameters.Description))
+        {
+            Console.WriteLine($"Description: {parameters.Description}");
+        }
+        await ShowGitHubLoginInformation(context, parameters.GitHubBotAccountSecret, helpUrl, parameters.GitHubBotAccountName);
+
         int expirationInDays = await Console.PromptAndValidateAsync<int>(
             "expiration in days",
             $"Expiration must be a whole number of days between {_minExpirationInDays} and {_maxExpirationInDays}.",
@@ -42,14 +50,6 @@ public class GitHubAccessToken : GitHubAccountInteractiveSecretType<GitHubAccess
         DateTimeOffset now = Clock.UtcNow;
         DateTimeOffset expiresOn = now.AddDays(expirationInDays);
         DateTimeOffset nextRotationOn = ComputeNextRotationOn(now, expirationInDays);
-
-        const string helpUrl = "https://github.com/settings/tokens";
-
-        if (!string.IsNullOrEmpty(parameters.Description))
-        {
-            Console.WriteLine($"Description: {parameters.Description}");
-        }
-        await ShowGitHubLoginInformation(context, parameters.GitHubBotAccountSecret, helpUrl, parameters.GitHubBotAccountName);
 
         string pat = await Console.PromptAndValidateAsync("PAT",
             $"PAT must have at least 40 characters and start with either '{_classicTokenPrefix}' or '{_fineGrainedTokenPrefix}'.",


### PR DESCRIPTION
## Summary

- show GitHub login and one-time-password information before requesting the PAT expiration duration
- keep the expiration-duration prompt immediately before PAT entry
- add regression coverage for the complete interaction order

## Testing

- `dotnet test src\SecretManager\Microsoft.DncEng.SecretManager.Tests\Microsoft.DncEng.SecretManager.Tests.csproj --filter "FullyQualifiedName~GitHubAccessTokenTests" --verbosity quiet`
