### PR TITLE
Fix Grafana dashboard retirement cleanup

### DIFF
--- a/src/Monitoring/Microsoft.DotNet.Monitoring.Sdk.Tests/GrafanaSerializationTests.cs
+++ b/src/Monitoring/Microsoft.DotNet.Monitoring.Sdk.Tests/GrafanaSerializationTests.cs
@@ -204,4 +204,45 @@ internal class GrafanaSerializationTests
 
         act.Should().Throw<ArgumentException>();
     }
+
+    [Test]
+    public void SetDashboardManagementTags_ReplacesExistingManagementTags()
+    {
+        var dashboard = new JObject
+        {
+            ["tags"] = new JArray("custom", "baseuid:old", "source:old")
+        };
+
+        GrafanaSerialization.SetDashboardManagementTags(dashboard, "home", "source:Monitoring.DncEng");
+
+        dashboard["tags"].Values<string>().Should().BeEquivalentTo(
+            "custom",
+            "baseuid:home",
+            "source:Monitoring.DncEng");
+    }
+
+    [Test]
+    public void IsManagedDashboard_RequiresMatchingUidAndSourceTags()
+    {
+        var dashboard = new JObject
+        {
+            ["uid"] = "home",
+            ["tags"] = new JArray("baseuid:home", "source:Monitoring.DncEng")
+        };
+
+        GrafanaSerialization.IsManagedDashboard(dashboard, "source:Monitoring.DncEng").Should().BeTrue();
+
+        dashboard["tags"] = new JArray("baseuid:other", "source:Monitoring.DncEng");
+        GrafanaSerialization.IsManagedDashboard(dashboard, "source:Monitoring.DncEng").Should().BeFalse();
+
+        dashboard["tags"] = new JArray("baseuid:home", "source:other");
+        GrafanaSerialization.IsManagedDashboard(dashboard, "source:Monitoring.DncEng").Should().BeFalse();
+    }
+
+    [Test]
+    public void ParseDashboardUidList_TrimsAndDeduplicatesValues()
+    {
+        GrafanaSerialization.ParseDashboardUidList(" home,other;home ; ")
+            .Should().Equal("home", "other");
+    }
 }

--- a/src/Monitoring/Monitoring.DncEng/parameters.json
+++ b/src/Monitoring/Monitoring.DncEng/parameters.json
@@ -182,6 +182,13 @@
     }
   },
   {
+    "Name": "retired-dashboard-uids",
+    "Values": {
+      "Staging": "home",
+      "Production": "home"
+    }
+  },
+  {
     "Name": "dnceng-folderid",
     "Values": {
       "Staging": "46",

--- a/src/Monitoring/Sdk/DeployPublisher.cs
+++ b/src/Monitoring/Sdk/DeployPublisher.cs
@@ -82,9 +82,13 @@ public sealed class DeployPublisher : DeployToolBase, IDisposable
 
         await PostAlertRulesAsync().ConfigureAwait(false);
 
-        await PostDashboardsAsync().ConfigureAwait(false);
+        HashSet<string> knownDashboardUids = await PostDashboardsAsync().ConfigureAwait(false);
 
         await SetHomeDashboardAsync().ConfigureAwait(false);
+
+        await ClearExtraneousDashboardsAsync(knownDashboardUids).ConfigureAwait(false);
+
+        await DeleteRetiredDashboardsAsync().ConfigureAwait(false);
     }
 
     private async Task PostDatasourcesAsync()
@@ -240,7 +244,7 @@ public sealed class DeployPublisher : DeployToolBase, IDisposable
         }
     }
 
-    private async Task PostDashboardsAsync()
+    private async Task<HashSet<string>> PostDashboardsAsync()
     {
         JArray folderArray = await GrafanaClient.ListFoldersAsync().ConfigureAwait(false);
         List<FolderData> folders = folderArray.Select(f => new FolderData(f.Value<string>("uid"), f.Value<string>("title")))
@@ -283,32 +287,7 @@ public sealed class DeployPublisher : DeployToolBase, IDisposable
                 data = await JObject.LoadAsync(jr).ConfigureAwait(false);
             }
 
-            JArray tagArray = null;
-            if (data.TryGetValue("tags", out JToken tagToken))
-            {
-                tagArray = tagToken as JArray;
-            }
-
-            if (tagArray == null)
-            {
-                tagArray = new JArray();
-            }
-
-            var newTags = new JArray();
-            foreach (JToken tag in tagArray)
-            {
-                if (tag.Value<string>().StartsWith(BaseUidTagPrefix) ||
-                    tag.Value<string>().StartsWith(SourceTagPrefix))
-                {
-                    continue;
-                }
-
-                newTags.Add(tag);
-            }
-
-            tagArray.Add(GetUidTag(uid));
-            tagArray.Add(SourceTag);
-            data["tags"] = newTags;
+            GrafanaSerialization.SetDashboardManagementTags(data, uid, SourceTag);
             data["uid"] = uid;
 
             data = GrafanaSerialization.DeparameterizeDashboard(data, parameters, _environment);
@@ -318,13 +297,16 @@ public sealed class DeployPublisher : DeployToolBase, IDisposable
             await GrafanaClient.CreateDashboardAsync(data, folderId).ConfigureAwait(false);
         }
 
-        await ClearExtraneousDashboardsAsync(knownUids);
+        return knownUids;
     }
 
     private async Task ClearExtraneousDashboardsAsync(HashSet<string> knownUids)
     {
         JArray allTagged = await GrafanaClient.SearchDashboardsByTagAsync(SourceTag).ConfigureAwait(false);
-        HashSet<string> toRemove =  new HashSet<string>(allTagged.Where(IsManagedDashboard).Select(d => d.Value<string>("uid")));
+        HashSet<string> toRemove = new HashSet<string>(
+            allTagged
+                .Where(d => GrafanaSerialization.IsManagedDashboard(d, SourceTag))
+                .Select(d => d.Value<string>("uid")));
 
         // We shouldn't remove the ones we just deployed
         toRemove.ExceptWith(knownUids);
@@ -336,12 +318,40 @@ public sealed class DeployPublisher : DeployToolBase, IDisposable
         }
     }
 
-    private static bool IsManagedDashboard(JToken d)
+    private async Task DeleteRetiredDashboardsAsync()
     {
-        string uid = d.Value<string>("uid");
-        // If the uid tag (which we set whenever we publish) doesn't match, that means someone copied it
-        // so it's not managed by us. If it does match, that means it is managed and we deployed it
-        return uid == d.Value<JObject>()?.Value<string>(GetUidTag(uid));
+        List<Parameter> parameters;
+        using (var sr = new StreamReader(_parameterFile))
+        using (var jr = new JsonTextReader(sr))
+        {
+            parameters = new JsonSerializer().Deserialize<List<Parameter>>(jr);
+        }
+
+        Parameter retiredDashboardParameter = parameters?
+            .FirstOrDefault(parameter => parameter.Name == "retired-dashboard-uids");
+        if (retiredDashboardParameter == null ||
+            !retiredDashboardParameter.Values.TryGetValue(_environment, out string retiredDashboardValue))
+        {
+            return;
+        }
+
+        var knownUids = new HashSet<string>(
+            GetAllDashboardPaths()
+                .Select(Path.GetFileName)
+                .Select(GetUidFromDashboardFile),
+            StringComparer.Ordinal);
+
+        foreach (string uid in GrafanaSerialization.ParseDashboardUidList(retiredDashboardValue))
+        {
+            if (knownUids.Contains(uid))
+            {
+                throw new InvalidOperationException(
+                    $"Dashboard '{uid}' cannot be both deployed and explicitly retired.");
+            }
+
+            Log.LogMessage(MessageImportance.Normal, "Ensuring explicitly retired dashboard {0} is absent...", uid);
+            await GrafanaClient.DeleteDashboardAsync(uid).ConfigureAwait(false);
+        }
     }
 
     public async Task<JToken> ReplaceVaultAsync(JToken data)

--- a/src/Monitoring/Sdk/GrafanaClient.cs
+++ b/src/Monitoring/Sdk/GrafanaClient.cs
@@ -352,6 +352,11 @@ public sealed class GrafanaClient : IDisposable
 
         using (HttpResponseMessage response = await _client.DeleteAsync(uri).ConfigureAwait(false))
         {
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return;
+            }
+
             await response.EnsureSuccessWithContentAsync();
         }
     }

--- a/src/Monitoring/Sdk/GrafanaSerialization.cs
+++ b/src/Monitoring/Sdk/GrafanaSerialization.cs
@@ -15,6 +15,9 @@ namespace Microsoft.DotNet.Monitoring.Sdk;
 /// </summary>
 public static class GrafanaSerialization
 {
+    private const string BaseUidTagPrefix = "baseuid:";
+    private const string SourceTagPrefix = "source:";
+
     /// <summary>
     /// Extract the Folder ID of a Dashboard from a JSON object returned by the api/dashboards/uid endpoint
     /// </summary>
@@ -36,6 +39,40 @@ public static class GrafanaSerialization
         slimmedDashboard.Remove("uid");
         slimmedDashboard.Remove("version");
         return slimmedDashboard;
+    }
+
+    public static void SetDashboardManagementTags(JObject dashboard, string uid, string sourceTag)
+    {
+        var tags = dashboard["tags"] as JArray ?? new JArray();
+        var updatedTags = new JArray(tags
+            .Values<string>()
+            .Where(tag => !tag.StartsWith(BaseUidTagPrefix, StringComparison.Ordinal) &&
+                          !tag.StartsWith(SourceTagPrefix, StringComparison.Ordinal)));
+
+        updatedTags.Add(BaseUidTagPrefix + uid);
+        updatedTags.Add(sourceTag);
+        dashboard["tags"] = updatedTags;
+    }
+
+    public static bool IsManagedDashboard(JToken dashboard, string sourceTag)
+    {
+        string uid = dashboard.Value<string>("uid");
+        var tags = dashboard["tags"] as JArray;
+
+        return !string.IsNullOrEmpty(uid) &&
+               tags != null &&
+               tags.Values<string>().Contains(BaseUidTagPrefix + uid, StringComparer.Ordinal) &&
+               tags.Values<string>().Contains(sourceTag, StringComparer.Ordinal);
+    }
+
+    public static IReadOnlyCollection<string> ParseDashboardUidList(string value)
+    {
+        return (value ?? string.Empty)
+            .Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(uid => uid.Trim())
+            .Where(uid => uid.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
     }
 
     /// <summary>


### PR DESCRIPTION
## Context and deletion safety

The Monitoring SDK has long attempted to remove dashboards that it previously published but that are no longer present in source. It identifies those dashboards with ordinary Grafana dashboard tags written by the SDK:

- `baseuid:<uid>` records the exact source-derived dashboard UID.
- `source:<project>` records which monitoring project published it.

These are not Grafana-reserved tags. They are ownership markers defined by this SDK. Automatic stale-dashboard cleanup first searches for the exact `source:*` tag and then requires both that tag and a `baseuid:*` value matching the returned dashboard UID. A dashboard without both exact markers is excluded; arbitrary untagged or user-created dashboards are not swept.

The deployed dashboard with UID `home` is a one-time exception. It came from this repository's former `Monitoring.DncEng/dashboard/general/home.dashboard.json` (title `Home`), which PR #6679 removed. The deployed copy predates working ownership tags, so tag-guarded discovery cannot find it. This PR therefore names only the exact UID `home` in the staging and production retirement lists; it does not enumerate or delete other untagged dashboards. Grafana dashboard UIDs are unique within an organization, so the currently deployed `home` resource cannot simultaneously be a separate user dashboard.

The organization home preference is cleared before deletion because it currently points at UID `home`. Reversing that order would temporarily leave Grafana configured to open a missing dashboard. After staging and production both prove `/api/dashboards/uid/home` returns 404, the explicit `home` tombstone should be removed so a future user-created dashboard cannot inadvertently reuse an actively retired UID.
## Summary

- fix Monitoring SDK dashboard ownership tags so managed dashboards can be discovered and retired
- validate both the `baseuid:*` and `source:*` tags from Grafana search results before automatic deletion
- clear the Grafana home preference before deleting stale dashboards
- explicitly and idempotently retire the legacy untagged `home` dashboard in staging and production

## Root cause

PR #6679 removed the `home` dashboard definition and cleared the organization preference, but the existing cleanup path never discovered the deployed dashboard:

- ownership tags were added to one `JArray`, while a different array was serialized;
- the ownership guard looked for `baseuid:<uid>` as an object property instead of a member of the `tags` array.

Production currently has 123 dashboards and none carry the Monitoring SDK's `source:*` or `baseuid:*` tags. Successful deployments therefore cleared the preference but never attempted `Deleting extra dashboard home`.

The explicit retirement list handles that pre-existing untagged resource without treating arbitrary untagged dashboards as SDK-owned. Future deployments receive correct management tags and use guarded stale-resource cleanup.

## Validation

- `dotnet test src/Monitoring/Microsoft.DotNet.Monitoring.Sdk.Tests/Microsoft.DotNet.Monitoring.Sdk.Tests.csproj --configuration Release`
- `dotnet build src/Monitoring/Monitoring.DncEng/Monitoring.DncEng.proj --configuration Release --no-restore`

Production verification after merge must confirm:

- `/api/dashboards/uid/home` returns 404;
- organization home-dashboard preference remains clear;
- both work-item waiting-time alert rules remain enabled and unlinked from dashboard panels.

Fixes AB#10233

<!-- pr-stack -->
## PR stack

Merge these PRs from top to bottom in this table. After a parent merges, retarget the next PR to `main`.

| Order | PR | Change |
| --- | --- | --- |
| 1 | [#6701](https://github.com/dotnet/dnceng/pull/6701) | Fix Grafana dashboard retirement cleanup |
| 2 | [#6703](https://github.com/dotnet/dnceng/pull/6703) | Migrate Data Migration alerts to Grafana |
| 3 | [#6694](https://github.com/dotnet/dnceng/pull/6694) | Add GitHub webhook secret drift alert |
| 4 | [#6702](https://github.com/dotnet/dnceng/pull/6702) | Retire source.dot.net monitoring |
| 5 | [#6706](https://github.com/dotnet/dnceng/pull/6706) | Inventory V1 Grafana retirements in report-only mode |