### PR TITLE
Migrate Data Migration alerts to Grafana

### DIFF
--- a/src/Monitoring/Microsoft.DotNet.Monitoring.Sdk.Tests/GrafanaClientRetirementTests.cs
+++ b/src/Monitoring/Microsoft.DotNet.Monitoring.Sdk.Tests/GrafanaClientRetirementTests.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using AwesomeAssertions;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 namespace Microsoft.DotNet.Monitoring.Sdk.Tests;
@@ -89,6 +90,91 @@ internal class GrafanaClientRetirementTests
         referenced.Should().BeTrue();
     }
 
+    [Test]
+    public async Task SetAlertRuleGroupIntervalPreservesRulesAndVerifiesUpdate()
+    {
+        const string group = """
+            {
+              "title": "Data Migration Alerts",
+              "folderUid": "dnceng",
+              "interval": 60,
+              "rules": [
+                {
+                  "uid": "data-migration-job-processing-time",
+                  "title": "Data Migration Job Processing Time"
+                }
+              ]
+            }
+            """;
+        const string updatedGroup = """
+            {
+              "title": "Data Migration Alerts",
+              "folderUid": "dnceng",
+              "interval": 300,
+              "rules": [
+                {
+                  "uid": "data-migration-job-processing-time",
+                  "title": "Data Migration Job Processing Time"
+                }
+              ]
+            }
+            """;
+        var handler = new RecordingHandler(
+            Json(HttpStatusCode.OK, group),
+            Json(HttpStatusCode.Accepted, "{}"),
+            Json(HttpStatusCode.OK, updatedGroup));
+        using var client = new GrafanaClient("https://grafana.example", new HttpClient(handler));
+
+        await client.SetAlertRuleGroupIntervalAsync("dnceng", "Data Migration Alerts", 300);
+
+        handler.Requests.Select(request => request.Method).Should()
+            .Equal(HttpMethod.Get, HttpMethod.Put, HttpMethod.Get);
+        handler.Requests[1].Path.Should()
+            .Be("/api/v1/provisioning/folder/dnceng/rule-groups/Data%20Migration%20Alerts");
+        handler.Requests[1].DisableProvenance.Should().Be("true");
+        JObject requestBody = JObject.Parse(handler.Requests[1].Body);
+        requestBody.Value<int>("interval").Should().Be(300);
+        requestBody.Value<JArray>("rules").Should().ContainSingle();
+        requestBody.SelectToken("rules[0].uid").Value<string>().Should()
+            .Be("data-migration-job-processing-time");
+    }
+
+    [Test]
+    public async Task SetAlertRuleGroupIntervalRejectsDroppedRules()
+    {
+        const string group = """
+            {
+              "title": "Data Migration Alerts",
+              "folderUid": "dnceng",
+              "interval": 60,
+              "rules": [
+                {
+                  "uid": "data-migration-job-processing-time",
+                  "title": "Data Migration Job Processing Time"
+                }
+              ]
+            }
+            """;
+        var handler = new RecordingHandler(
+            Json(HttpStatusCode.OK, group),
+            Json(HttpStatusCode.Accepted, "{}"),
+            Json(HttpStatusCode.OK, """
+                {
+                  "title": "Data Migration Alerts",
+                  "folderUid": "dnceng",
+                  "interval": 300,
+                  "rules": []
+                }
+                """));
+        using var client = new GrafanaClient("https://grafana.example", new HttpClient(handler));
+
+        Func<Task> update = () =>
+            client.SetAlertRuleGroupIntervalAsync("dnceng", "Data Migration Alerts", 300);
+
+        await update.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*changed its rule set*");
+    }
+
     private static HttpResponseMessage Json(HttpStatusCode statusCode, string content) =>
         new(statusCode) { Content = new StringContent(content) };
 
@@ -103,19 +189,23 @@ internal class GrafanaClientRetirementTests
 
         public List<Request> Requests { get; } = new();
 
-        protected override Task<HttpResponseMessage> SendAsync(
+        protected override async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
+            string body = request.Content == null
+                ? null
+                : await request.Content.ReadAsStringAsync().ConfigureAwait(false);
             Requests.Add(new Request(
                 request.Method,
                 request.RequestUri.AbsolutePath,
                 request.Headers.TryGetValues("X-Disable-Provenance", out IEnumerable<string> values)
                     ? values.Single()
-                    : null));
-            return Task.FromResult(_responses.Dequeue());
+                    : null,
+                body));
+            return _responses.Dequeue();
         }
     }
 
-    private sealed record Request(HttpMethod Method, string Path, string DisableProvenance);
+    private sealed record Request(HttpMethod Method, string Path, string DisableProvenance, string Body);
 }

--- a/src/Monitoring/Monitoring.DncEng/alertrules/Production/data-migration-job-processing-time.alert.json
+++ b/src/Monitoring/Monitoring.DncEng/alertrules/Production/data-migration-job-processing-time.alert.json
@@ -1,0 +1,117 @@
+{
+  "uid": "data-migration-job-processing-time",
+  "title": "Data Migration Job Processing Time",
+  "condition": "C",
+  "data": [
+    {
+      "refId": "A",
+      "queryType": "Azure Monitor",
+      "datasourceUid": "F2XodEi7z",
+      "relativeTimeRange": {
+        "from": 300,
+        "to": 0
+      },
+      "model": {
+        "azureMonitor": {
+          "aggregation": "Average",
+          "customNamespace": "Azure.ApplicationInsights",
+          "dimensionFilters": [],
+          "metricDefinition": "Microsoft.Insights/components",
+          "metricName": "DataMigrationJobProcessingTimeInSeconds",
+          "metricNamespace": "Microsoft.Insights/components",
+          "resources": [
+            {
+              "metricNamespace": "Microsoft.Insights/components",
+              "resourceGroup": "helixinfrarg",
+              "resourceName": "helix-prod",
+              "subscription": "68672ab8-de0c-40f1-8d1b-ffb20bd62c0f"
+            }
+          ],
+          "timeGrain": "PT5M"
+        },
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "F2XodEi7z"
+        },
+        "queryType": "Azure Monitor",
+        "refId": "A",
+        "subscription": "68672ab8-de0c-40f1-8d1b-ffb20bd62c0f",
+        "subscriptions": [
+          "68672ab8-de0c-40f1-8d1b-ffb20bd62c0f"
+        ]
+      }
+    },
+    {
+      "refId": "B",
+      "queryType": "",
+      "datasourceUid": "-100",
+      "relativeTimeRange": {
+        "from": 300,
+        "to": 0
+      },
+      "model": {
+        "datasource": {
+          "type": "__expr__",
+          "uid": "-100"
+        },
+        "expression": "A",
+        "reducer": "last",
+        "refId": "B",
+        "type": "reduce"
+      }
+    },
+    {
+      "refId": "C",
+      "queryType": "",
+      "datasourceUid": "-100",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                300
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "B"
+              ]
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "-100"
+        },
+        "expression": "B",
+        "refId": "C",
+        "type": "threshold"
+      }
+    }
+  ],
+  "noDataState": "OK",
+  "execErrState": "KeepLast",
+  "for": "0s",
+  "frequency": "5m",
+  "annotations": {
+    "description": "The average DataMigration job processing time exceeded 300 seconds during the last five minutes. Investigate the Helix production data-migration pipeline. Migration and parity evidence are tracked by AB#12370."
+  },
+  "labels": {
+    "NotificationId": "data-migration-job-processing-time"
+  },
+  "folderUID": "dnceng",
+  "ruleGroup": "Data Migration Alerts",
+  "evaluationIntervalSeconds": 300,
+  "intervalMs": 300000,
+  "isPaused": false,
+  "notification_settings": {
+    "receiver": "amg-icm-ddfun-customer-requests",
+    "group_wait": "0s",
+    "repeat_interval": "4h"
+  }
+}

--- a/src/Monitoring/Monitoring.DncEng/alertrules/Production/kusto-processor-exceptions.alert.json
+++ b/src/Monitoring/Monitoring.DncEng/alertrules/Production/kusto-processor-exceptions.alert.json
@@ -1,0 +1,116 @@
+{
+  "uid": "kusto-processor-exceptions",
+  "title": "Kusto Processor Exceptions",
+  "condition": "C",
+  "data": [
+    {
+      "refId": "A",
+      "queryType": "Azure Monitor",
+      "datasourceUid": "F2XodEi7z",
+      "relativeTimeRange": {
+        "from": 900,
+        "to": 0
+      },
+      "model": {
+        "azureMonitor": {
+          "aggregation": "Count",
+          "dimensionFilters": [],
+          "metricDefinition": "Microsoft.Insights/components",
+          "metricName": "exceptions/server",
+          "metricNamespace": "Microsoft.Insights/components",
+          "resources": [
+            {
+              "metricNamespace": "Microsoft.Insights/components",
+              "resourceGroup": "HelixMonitoring",
+              "resourceName": "KustoProcessor-Prod",
+              "subscription": "68672ab8-de0c-40f1-8d1b-ffb20bd62c0f"
+            }
+          ],
+          "timeGrain": "PT15M"
+        },
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "F2XodEi7z"
+        },
+        "queryType": "Azure Monitor",
+        "refId": "A",
+        "subscription": "68672ab8-de0c-40f1-8d1b-ffb20bd62c0f",
+        "subscriptions": [
+          "68672ab8-de0c-40f1-8d1b-ffb20bd62c0f"
+        ]
+      }
+    },
+    {
+      "refId": "B",
+      "queryType": "",
+      "datasourceUid": "-100",
+      "relativeTimeRange": {
+        "from": 900,
+        "to": 0
+      },
+      "model": {
+        "datasource": {
+          "type": "__expr__",
+          "uid": "-100"
+        },
+        "expression": "A",
+        "reducer": "last",
+        "refId": "B",
+        "type": "reduce"
+      }
+    },
+    {
+      "refId": "C",
+      "queryType": "",
+      "datasourceUid": "-100",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                0
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "B"
+              ]
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "-100"
+        },
+        "expression": "B",
+        "refId": "C",
+        "type": "threshold"
+      }
+    }
+  ],
+  "noDataState": "OK",
+  "execErrState": "KeepLast",
+  "for": "0s",
+  "frequency": "5m",
+  "annotations": {
+    "description": "KustoProcessor-Prod reported one or more server exceptions during the last 15 minutes. The rule remains paused to preserve the disabled state of the native production alert until parity is proven. Migration and parity evidence are tracked by AB#12370."
+  },
+  "labels": {
+    "NotificationId": "kusto-processor-exceptions"
+  },
+  "folderUID": "dnceng",
+  "ruleGroup": "Data Migration Alerts",
+  "evaluationIntervalSeconds": 300,
+  "intervalMs": 300000,
+  "isPaused": true,
+  "notification_settings": {
+    "receiver": "amg-icm-ddfun-customer-requests",
+    "group_wait": "0s",
+    "repeat_interval": "4h"
+  }
+}

--- a/src/Monitoring/Monitoring.DncEng/alertrules/Production/kusto-processor-message-delay.alert.json
+++ b/src/Monitoring/Monitoring.DncEng/alertrules/Production/kusto-processor-message-delay.alert.json
@@ -1,0 +1,117 @@
+{
+  "uid": "kusto-processor-message-delay",
+  "title": "Kusto Processor Message Delay",
+  "condition": "C",
+  "data": [
+    {
+      "refId": "A",
+      "queryType": "Azure Monitor",
+      "datasourceUid": "F2XodEi7z",
+      "relativeTimeRange": {
+        "from": 300,
+        "to": 0
+      },
+      "model": {
+        "azureMonitor": {
+          "aggregation": "Average",
+          "customNamespace": "Azure.ApplicationInsights",
+          "dimensionFilters": [],
+          "metricDefinition": "Microsoft.Insights/components",
+          "metricName": "MessageDelay",
+          "metricNamespace": "Microsoft.Insights/components",
+          "resources": [
+            {
+              "metricNamespace": "Microsoft.Insights/components",
+              "resourceGroup": "HelixMonitoring",
+              "resourceName": "KustoProcessor-Prod",
+              "subscription": "68672ab8-de0c-40f1-8d1b-ffb20bd62c0f"
+            }
+          ],
+          "timeGrain": "PT5M"
+        },
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "F2XodEi7z"
+        },
+        "queryType": "Azure Monitor",
+        "refId": "A",
+        "subscription": "68672ab8-de0c-40f1-8d1b-ffb20bd62c0f",
+        "subscriptions": [
+          "68672ab8-de0c-40f1-8d1b-ffb20bd62c0f"
+        ]
+      }
+    },
+    {
+      "refId": "B",
+      "queryType": "",
+      "datasourceUid": "-100",
+      "relativeTimeRange": {
+        "from": 300,
+        "to": 0
+      },
+      "model": {
+        "datasource": {
+          "type": "__expr__",
+          "uid": "-100"
+        },
+        "expression": "A",
+        "reducer": "last",
+        "refId": "B",
+        "type": "reduce"
+      }
+    },
+    {
+      "refId": "C",
+      "queryType": "",
+      "datasourceUid": "-100",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                6000
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "B"
+              ]
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "-100"
+        },
+        "expression": "B",
+        "refId": "C",
+        "type": "threshold"
+      }
+    }
+  ],
+  "noDataState": "OK",
+  "execErrState": "KeepLast",
+  "for": "0s",
+  "frequency": "5m",
+  "annotations": {
+    "description": "The average KustoProcessor-Prod MessageDelay exceeded 6000 during the last five minutes. The rule remains paused to preserve the disabled state of the native production alert until parity is proven. Migration and parity evidence are tracked by AB#12370."
+  },
+  "labels": {
+    "NotificationId": "kusto-processor-message-delay"
+  },
+  "folderUID": "dnceng",
+  "ruleGroup": "Data Migration Alerts",
+  "evaluationIntervalSeconds": 300,
+  "intervalMs": 300000,
+  "isPaused": true,
+  "notification_settings": {
+    "receiver": "amg-icm-ddfun-customer-requests",
+    "group_wait": "0s",
+    "repeat_interval": "4h"
+  }
+}

--- a/src/Monitoring/Monitoring.DncEng/alertrules/Staging/data-migration-job-processing-time.alert.json
+++ b/src/Monitoring/Monitoring.DncEng/alertrules/Staging/data-migration-job-processing-time.alert.json
@@ -1,0 +1,117 @@
+{
+  "uid": "data-migration-job-processing-time",
+  "title": "Data Migration Job Processing Time",
+  "condition": "C",
+  "data": [
+    {
+      "refId": "A",
+      "queryType": "Azure Monitor",
+      "datasourceUid": "F2XodEi7z",
+      "relativeTimeRange": {
+        "from": 300,
+        "to": 0
+      },
+      "model": {
+        "azureMonitor": {
+          "aggregation": "Average",
+          "customNamespace": "Azure.ApplicationInsights",
+          "dimensionFilters": [],
+          "metricDefinition": "Microsoft.Insights/components",
+          "metricName": "DataMigrationJobProcessingTimeInSeconds",
+          "metricNamespace": "Microsoft.Insights/components",
+          "resources": [
+            {
+              "metricNamespace": "Microsoft.Insights/components",
+              "resourceGroup": "helix-web",
+              "resourceName": "helixmonitoring-int",
+              "subscription": "cab65fc3-d077-467d-931f-3932eabf36d3"
+            }
+          ],
+          "timeGrain": "PT5M"
+        },
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "F2XodEi7z"
+        },
+        "queryType": "Azure Monitor",
+        "refId": "A",
+        "subscription": "cab65fc3-d077-467d-931f-3932eabf36d3",
+        "subscriptions": [
+          "cab65fc3-d077-467d-931f-3932eabf36d3"
+        ]
+      }
+    },
+    {
+      "refId": "B",
+      "queryType": "",
+      "datasourceUid": "-100",
+      "relativeTimeRange": {
+        "from": 300,
+        "to": 0
+      },
+      "model": {
+        "datasource": {
+          "type": "__expr__",
+          "uid": "-100"
+        },
+        "expression": "A",
+        "reducer": "last",
+        "refId": "B",
+        "type": "reduce"
+      }
+    },
+    {
+      "refId": "C",
+      "queryType": "",
+      "datasourceUid": "-100",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                300
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "B"
+              ]
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "-100"
+        },
+        "expression": "B",
+        "refId": "C",
+        "type": "threshold"
+      }
+    }
+  ],
+  "noDataState": "OK",
+  "execErrState": "KeepLast",
+  "for": "0s",
+  "frequency": "5m",
+  "annotations": {
+    "description": "The average staging DataMigration job processing time exceeded 300 seconds during the last five minutes. This staging rule validates migration parity without paging. Migration and parity evidence are tracked by AB#12370."
+  },
+  "labels": {
+    "NotificationId": "data-migration-job-processing-time"
+  },
+  "folderUID": "dnceng",
+  "ruleGroup": "Data Migration Alerts",
+  "evaluationIntervalSeconds": 300,
+  "intervalMs": 300000,
+  "isPaused": false,
+  "notification_settings": {
+    "receiver": "Teams Alert",
+    "group_wait": "0s",
+    "repeat_interval": "4h"
+  }
+}

--- a/src/Monitoring/Monitoring.DncEng/alertrules/Staging/kusto-processor-exceptions.alert.json
+++ b/src/Monitoring/Monitoring.DncEng/alertrules/Staging/kusto-processor-exceptions.alert.json
@@ -1,0 +1,116 @@
+{
+  "uid": "kusto-processor-exceptions",
+  "title": "Kusto Processor Exceptions",
+  "condition": "C",
+  "data": [
+    {
+      "refId": "A",
+      "queryType": "Azure Monitor",
+      "datasourceUid": "F2XodEi7z",
+      "relativeTimeRange": {
+        "from": 1800,
+        "to": 0
+      },
+      "model": {
+        "azureMonitor": {
+          "aggregation": "Count",
+          "dimensionFilters": [],
+          "metricDefinition": "Microsoft.Insights/components",
+          "metricName": "exceptions/server",
+          "metricNamespace": "Microsoft.Insights/components",
+          "resources": [
+            {
+              "metricNamespace": "Microsoft.Insights/components",
+              "resourceGroup": "HelixMonitoring",
+              "resourceName": "KustoProcessor-int",
+              "subscription": "cab65fc3-d077-467d-931f-3932eabf36d3"
+            }
+          ],
+          "timeGrain": "PT30M"
+        },
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "F2XodEi7z"
+        },
+        "queryType": "Azure Monitor",
+        "refId": "A",
+        "subscription": "cab65fc3-d077-467d-931f-3932eabf36d3",
+        "subscriptions": [
+          "cab65fc3-d077-467d-931f-3932eabf36d3"
+        ]
+      }
+    },
+    {
+      "refId": "B",
+      "queryType": "",
+      "datasourceUid": "-100",
+      "relativeTimeRange": {
+        "from": 1800,
+        "to": 0
+      },
+      "model": {
+        "datasource": {
+          "type": "__expr__",
+          "uid": "-100"
+        },
+        "expression": "A",
+        "reducer": "last",
+        "refId": "B",
+        "type": "reduce"
+      }
+    },
+    {
+      "refId": "C",
+      "queryType": "",
+      "datasourceUid": "-100",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                0
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "B"
+              ]
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "-100"
+        },
+        "expression": "B",
+        "refId": "C",
+        "type": "threshold"
+      }
+    }
+  ],
+  "noDataState": "OK",
+  "execErrState": "KeepLast",
+  "for": "0s",
+  "frequency": "5m",
+  "annotations": {
+    "description": "KustoProcessor-int reported one or more server exceptions during the last 30 minutes. This staging rule validates migration parity without paging. Migration and parity evidence are tracked by AB#12370."
+  },
+  "labels": {
+    "NotificationId": "kusto-processor-exceptions"
+  },
+  "folderUID": "dnceng",
+  "ruleGroup": "Data Migration Alerts",
+  "evaluationIntervalSeconds": 300,
+  "intervalMs": 300000,
+  "isPaused": false,
+  "notification_settings": {
+    "receiver": "Teams Alert",
+    "group_wait": "0s",
+    "repeat_interval": "4h"
+  }
+}

--- a/src/Monitoring/Monitoring.DncEng/alertrules/Staging/kusto-processor-message-delay.alert.json
+++ b/src/Monitoring/Monitoring.DncEng/alertrules/Staging/kusto-processor-message-delay.alert.json
@@ -1,0 +1,117 @@
+{
+  "uid": "kusto-processor-message-delay",
+  "title": "Kusto Processor Message Delay",
+  "condition": "C",
+  "data": [
+    {
+      "refId": "A",
+      "queryType": "Azure Monitor",
+      "datasourceUid": "F2XodEi7z",
+      "relativeTimeRange": {
+        "from": 900,
+        "to": 0
+      },
+      "model": {
+        "azureMonitor": {
+          "aggregation": "Average",
+          "customNamespace": "Azure.ApplicationInsights",
+          "dimensionFilters": [],
+          "metricDefinition": "Microsoft.Insights/components",
+          "metricName": "MessageDelay",
+          "metricNamespace": "Microsoft.Insights/components",
+          "resources": [
+            {
+              "metricNamespace": "Microsoft.Insights/components",
+              "resourceGroup": "HelixMonitoring",
+              "resourceName": "KustoProcessor-int",
+              "subscription": "cab65fc3-d077-467d-931f-3932eabf36d3"
+            }
+          ],
+          "timeGrain": "PT15M"
+        },
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "F2XodEi7z"
+        },
+        "queryType": "Azure Monitor",
+        "refId": "A",
+        "subscription": "cab65fc3-d077-467d-931f-3932eabf36d3",
+        "subscriptions": [
+          "cab65fc3-d077-467d-931f-3932eabf36d3"
+        ]
+      }
+    },
+    {
+      "refId": "B",
+      "queryType": "",
+      "datasourceUid": "-100",
+      "relativeTimeRange": {
+        "from": 900,
+        "to": 0
+      },
+      "model": {
+        "datasource": {
+          "type": "__expr__",
+          "uid": "-100"
+        },
+        "expression": "A",
+        "reducer": "last",
+        "refId": "B",
+        "type": "reduce"
+      }
+    },
+    {
+      "refId": "C",
+      "queryType": "",
+      "datasourceUid": "-100",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                6000
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "B"
+              ]
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "-100"
+        },
+        "expression": "B",
+        "refId": "C",
+        "type": "threshold"
+      }
+    }
+  ],
+  "noDataState": "OK",
+  "execErrState": "KeepLast",
+  "for": "0s",
+  "frequency": "5m",
+  "annotations": {
+    "description": "The average KustoProcessor-int MessageDelay exceeded 6000 during the last 15 minutes. This staging rule validates migration parity without paging. Migration and parity evidence are tracked by AB#12370."
+  },
+  "labels": {
+    "NotificationId": "kusto-processor-message-delay"
+  },
+  "folderUID": "dnceng",
+  "ruleGroup": "Data Migration Alerts",
+  "evaluationIntervalSeconds": 300,
+  "intervalMs": 300000,
+  "isPaused": false,
+  "notification_settings": {
+    "receiver": "Teams Alert",
+    "group_wait": "0s",
+    "repeat_interval": "4h"
+  }
+}

--- a/src/Monitoring/Sdk/DeployPublisher.cs
+++ b/src/Monitoring/Sdk/DeployPublisher.cs
@@ -338,6 +338,8 @@ public sealed class DeployPublisher : DeployToolBase, IDisposable
         // Ensure all folders referenced by alert rules exist before posting rules
         var alertRuleFiles = Directory.GetFiles(AlertRuleDirectory, "*" + AlertRuleExtension, SearchOption.AllDirectories);
         var seenFolderUids = new HashSet<string>(StringComparer.Ordinal);
+        var ruleGroupIntervals = new Dictionary<(string FolderUid, string RuleGroup), int>();
+        var ruleGroupsWithoutExplicitIntervals = new HashSet<(string FolderUid, string RuleGroup)>();
         foreach (string alertRulePath in alertRuleFiles)
         {
             JObject data;
@@ -352,6 +354,49 @@ public sealed class DeployPublisher : DeployToolBase, IDisposable
             {
                 Log.LogMessage(MessageImportance.Normal, "Ensuring alert rule folder '{0}' exists...", folderUID);
                 await GrafanaClient.CreateFolderAsync(folderUID, folderUID).ConfigureAwait(false);
+            }
+
+            string ruleGroup = data.Value<string>("ruleGroup");
+            if (!string.IsNullOrEmpty(folderUID) && !string.IsNullOrEmpty(ruleGroup))
+            {
+                var key = (folderUID, ruleGroup);
+                if (data.TryGetValue("evaluationIntervalSeconds", out JToken intervalToken))
+                {
+                    int intervalSeconds = intervalToken.Type == JTokenType.Integer
+                        ? intervalToken.Value<int>()
+                        : 0;
+                    if (intervalSeconds <= 0)
+                    {
+                        throw new InvalidOperationException(
+                            $"Alert rule {alertRulePath} must specify a positive evaluationIntervalSeconds.");
+                    }
+
+                    if (ruleGroupsWithoutExplicitIntervals.Contains(key))
+                    {
+                        throw new InvalidOperationException(
+                            $"Every managed rule in alert rule group '{folderUID}/{ruleGroup}' must specify evaluationIntervalSeconds.");
+                    }
+
+                    if (ruleGroupIntervals.TryGetValue(key, out int existingInterval) &&
+                        existingInterval != intervalSeconds)
+                    {
+                        throw new InvalidOperationException(
+                            $"Alert rule group '{folderUID}/{ruleGroup}' has conflicting evaluation intervals: " +
+                            $"{existingInterval} and {intervalSeconds} seconds.");
+                    }
+
+                    ruleGroupIntervals[key] = intervalSeconds;
+                }
+                else
+                {
+                    if (ruleGroupIntervals.ContainsKey(key))
+                    {
+                        throw new InvalidOperationException(
+                            $"Every managed rule in alert rule group '{folderUID}/{ruleGroup}' must specify evaluationIntervalSeconds.");
+                    }
+
+                    ruleGroupsWithoutExplicitIntervals.Add(key);
+                }
             }
         }
 
@@ -372,6 +417,7 @@ public sealed class DeployPublisher : DeployToolBase, IDisposable
 
             // Replace [parameter(...)] placeholders with environment-specific values
             data = GrafanaSerialization.DeparameterizeDashboard(data, parameters, _environment);
+            data.Remove("evaluationIntervalSeconds");
 
             // Log the final JSON for debugging
             Log.LogMessage(MessageImportance.High, "Alert JSON after parameter replacement: {0}", data.ToString(Formatting.Indented));
@@ -379,6 +425,20 @@ public sealed class DeployPublisher : DeployToolBase, IDisposable
             await ReplaceVaultAsync(data);
 
             await GrafanaClient.CreateAlertRuleAsync(data).ConfigureAwait(false);
+        }
+
+        foreach (KeyValuePair<(string FolderUid, string RuleGroup), int> interval in ruleGroupIntervals)
+        {
+            Log.LogMessage(
+                MessageImportance.Normal,
+                "Setting alert rule group {0}/{1} evaluation interval to {2} seconds...",
+                interval.Key.FolderUid,
+                interval.Key.RuleGroup,
+                interval.Value);
+            await GrafanaClient.SetAlertRuleGroupIntervalAsync(
+                interval.Key.FolderUid,
+                interval.Key.RuleGroup,
+                interval.Value).ConfigureAwait(false);
         }
     }
 

--- a/src/Monitoring/Sdk/DeployPublisher.cs
+++ b/src/Monitoring/Sdk/DeployPublisher.cs
@@ -92,11 +92,77 @@ public sealed class DeployPublisher : DeployToolBase, IDisposable
 
         await RetireResourcesAsync().ConfigureAwait(false);
 
+        await RetireResourcesAsync().ConfigureAwait(false);
+
         await SetHomeDashboardAsync().ConfigureAwait(false);
 
         await ClearExtraneousDashboardsAsync(knownDashboardUids).ConfigureAwait(false);
 
         await DeleteRetiredDashboardsAsync().ConfigureAwait(false);
+    }
+
+    private async Task RetireResourcesAsync()
+    {
+        string retirementPath = Path.Combine(_retirementDirectory, _environment + ".retirement.json");
+        if (!File.Exists(retirementPath))
+        {
+            return;
+        }
+
+        JObject retirementPlan;
+        using (var streamReader = new StreamReader(retirementPath))
+        using (var jsonReader = new JsonTextReader(streamReader))
+        {
+            retirementPlan = await JObject.LoadAsync(jsonReader).ConfigureAwait(false);
+        }
+
+        string[] alertRuleUids = retirementPlan.Value<JArray>("alertRules")?
+            .Values<string>()
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray() ?? Array.Empty<string>();
+        string[] contactPointNames = retirementPlan.Value<JArray>("contactPoints")?
+            .Values<string>()
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray() ?? Array.Empty<string>();
+
+        if (!_allowDeletes)
+        {
+            Log.LogWarning(
+                "Grafana retirement plan {0} is in report-only mode. Would delete {1} alert rule(s) and {2} contact point(s).",
+                retirementPath,
+                alertRuleUids.Length,
+                contactPointNames.Length);
+            return;
+        }
+
+        foreach (string uid in alertRuleUids)
+        {
+            bool deleted = await GrafanaClient.DeleteAlertRuleAsync(uid).ConfigureAwait(false);
+            Log.LogMessage(
+                MessageImportance.High,
+                deleted ? "Deleted retired alert rule {0}." : "Retired alert rule {0} was already absent.",
+                uid);
+        }
+
+        foreach (string name in contactPointNames)
+        {
+            if (await GrafanaClient.NotificationPolicyReferencesContactPointAsync(name).ConfigureAwait(false))
+            {
+                throw new InvalidOperationException(
+                    $"Grafana notification policy still references contact point '{name}'. Remove the route before deleting the contact point.");
+            }
+
+            int deleted = await GrafanaClient.DeleteContactPointsByNameAsync(name).ConfigureAwait(false);
+            Log.LogMessage(
+                MessageImportance.High,
+                deleted == 0
+                    ? "Retired contact point {0} was already absent."
+                    : "Deleted {1} integration(s) for retired contact point {0}.",
+                name,
+                deleted);
+        }
     }
 
     private async Task RetireResourcesAsync()

--- a/src/Monitoring/Sdk/DeployPublisher.cs
+++ b/src/Monitoring/Sdk/DeployPublisher.cs
@@ -92,77 +92,11 @@ public sealed class DeployPublisher : DeployToolBase, IDisposable
 
         await RetireResourcesAsync().ConfigureAwait(false);
 
-        await RetireResourcesAsync().ConfigureAwait(false);
-
         await SetHomeDashboardAsync().ConfigureAwait(false);
 
         await ClearExtraneousDashboardsAsync(knownDashboardUids).ConfigureAwait(false);
 
         await DeleteRetiredDashboardsAsync().ConfigureAwait(false);
-    }
-
-    private async Task RetireResourcesAsync()
-    {
-        string retirementPath = Path.Combine(_retirementDirectory, _environment + ".retirement.json");
-        if (!File.Exists(retirementPath))
-        {
-            return;
-        }
-
-        JObject retirementPlan;
-        using (var streamReader = new StreamReader(retirementPath))
-        using (var jsonReader = new JsonTextReader(streamReader))
-        {
-            retirementPlan = await JObject.LoadAsync(jsonReader).ConfigureAwait(false);
-        }
-
-        string[] alertRuleUids = retirementPlan.Value<JArray>("alertRules")?
-            .Values<string>()
-            .Where(value => !string.IsNullOrWhiteSpace(value))
-            .Distinct(StringComparer.Ordinal)
-            .ToArray() ?? Array.Empty<string>();
-        string[] contactPointNames = retirementPlan.Value<JArray>("contactPoints")?
-            .Values<string>()
-            .Where(value => !string.IsNullOrWhiteSpace(value))
-            .Distinct(StringComparer.Ordinal)
-            .ToArray() ?? Array.Empty<string>();
-
-        if (!_allowDeletes)
-        {
-            Log.LogWarning(
-                "Grafana retirement plan {0} is in report-only mode. Would delete {1} alert rule(s) and {2} contact point(s).",
-                retirementPath,
-                alertRuleUids.Length,
-                contactPointNames.Length);
-            return;
-        }
-
-        foreach (string uid in alertRuleUids)
-        {
-            bool deleted = await GrafanaClient.DeleteAlertRuleAsync(uid).ConfigureAwait(false);
-            Log.LogMessage(
-                MessageImportance.High,
-                deleted ? "Deleted retired alert rule {0}." : "Retired alert rule {0} was already absent.",
-                uid);
-        }
-
-        foreach (string name in contactPointNames)
-        {
-            if (await GrafanaClient.NotificationPolicyReferencesContactPointAsync(name).ConfigureAwait(false))
-            {
-                throw new InvalidOperationException(
-                    $"Grafana notification policy still references contact point '{name}'. Remove the route before deleting the contact point.");
-            }
-
-            int deleted = await GrafanaClient.DeleteContactPointsByNameAsync(name).ConfigureAwait(false);
-            Log.LogMessage(
-                MessageImportance.High,
-                deleted == 0
-                    ? "Retired contact point {0} was already absent."
-                    : "Deleted {1} integration(s) for retired contact point {0}.",
-                name,
-                deleted);
-        }
     }
 
     private async Task RetireResourcesAsync()

--- a/src/Monitoring/Sdk/GrafanaClient.cs
+++ b/src/Monitoring/Sdk/GrafanaClient.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -550,6 +551,86 @@ public sealed class GrafanaClient : IDisposable
                 
                 var updateUri = new Uri(new Uri(_baseUrl), $"/api/v1/provisioning/alert-rules/{Uri.EscapeDataString(uid)}");
                 await SendObjectAsync(alertRule, updateUri, HttpMethod.Put).ConfigureAwait(false);
+            }
+        }
+    }
+
+    public async Task SetAlertRuleGroupIntervalAsync(string folderUid, string ruleGroup, int intervalSeconds)
+    {
+        if (intervalSeconds <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(intervalSeconds));
+        }
+
+        var uri = new Uri(
+            new Uri(_baseUrl),
+            $"/api/v1/provisioning/folder/{Uri.EscapeDataString(folderUid)}/rule-groups/{Uri.EscapeDataString(ruleGroup)}");
+        JObject group = await GetObjectAsync(uri).ConfigureAwait(false);
+        if (group.Value<int>("interval") == intervalSeconds)
+        {
+            return;
+        }
+
+        string[] ruleUids = GetRuleGroupUids(group, folderUid, ruleGroup);
+        group["interval"] = intervalSeconds;
+        using (var content = new StringContent(group.ToString(Formatting.None)))
+        {
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            using (var request = new HttpRequestMessage(HttpMethod.Put, uri) { Content = content })
+            {
+                request.Headers.Add("X-Disable-Provenance", "true");
+                using (HttpResponseMessage response = await _client.SendAsync(request).ConfigureAwait(false))
+                {
+                    await response.EnsureSuccessWithContentAsync();
+                }
+            }
+        }
+
+        JObject updated = await GetObjectAsync(uri).ConfigureAwait(false);
+        if (updated.Value<int>("interval") != intervalSeconds)
+        {
+            throw new InvalidOperationException(
+                $"Grafana alert rule group '{folderUid}/{ruleGroup}' did not retain the {intervalSeconds}-second interval.");
+        }
+
+        string[] updatedRuleUids = GetRuleGroupUids(updated, folderUid, ruleGroup);
+        if (!new HashSet<string>(ruleUids, StringComparer.Ordinal).SetEquals(updatedRuleUids))
+        {
+            throw new InvalidOperationException(
+                $"Grafana alert rule group '{folderUid}/{ruleGroup}' changed its rule set while updating the interval.");
+        }
+    }
+
+    private static string[] GetRuleGroupUids(JObject group, string folderUid, string ruleGroup)
+    {
+        JArray rules = group.Value<JArray>("rules")
+            ?? throw new InvalidOperationException(
+                $"Grafana alert rule group '{folderUid}/{ruleGroup}' did not return a rules array.");
+        string[] uids = rules
+            .OfType<JObject>()
+            .Select(rule => rule.Value<string>("uid"))
+            .Where(uid => !string.IsNullOrEmpty(uid))
+            .ToArray();
+        if (uids.Length != rules.Count || uids.Distinct(StringComparer.Ordinal).Count() != uids.Length)
+        {
+            throw new InvalidOperationException(
+                $"Grafana alert rule group '{folderUid}/{ruleGroup}' returned missing or duplicate rule UIDs.");
+        }
+
+        return uids;
+    }
+
+    private async Task<JObject> GetObjectAsync(Uri uri)
+    {
+        using (HttpResponseMessage response = await _client.GetAsync(uri).ConfigureAwait(false))
+        {
+            await response.EnsureSuccessWithContentAsync();
+
+            using (Stream stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+            using (var streamReader = new StreamReader(stream))
+            using (var jsonReader = new JsonTextReader(streamReader))
+            {
+                return await JObject.LoadAsync(jsonReader).ConfigureAwait(false);
             }
         }
     }

--- a/src/Monitoring/Sdk/README.md
+++ b/src/Monitoring/Sdk/README.md
@@ -17,6 +17,24 @@ Projects can override these locations:
 </PropertyGroup>
 ```
 
+## Control alert rule evaluation cadence
+
+Grafana evaluates every rule in a rule group at the group's interval. To manage that
+interval, set `evaluationIntervalSeconds` on every managed rule in the group:
+
+```json
+{
+  "folderUID": "dnceng",
+  "ruleGroup": "Data Migration Alerts",
+  "evaluationIntervalSeconds": 300
+}
+```
+
+The SDK removes this deployment-only field from the individual rule payload, then updates
+the complete Grafana rule group after all rules are published. Rules in the same group must
+specify the same positive interval. Omitting the field leaves the existing Grafana group
+interval unchanged.
+
 ## Retire managed resources
 
 Removing an alert-rule or contact-point definition does not remove the deployed Grafana

--- a/src/Monitoring/Sdk/README.md
+++ b/src/Monitoring/Sdk/README.md
@@ -30,6 +30,11 @@ interval, set `evaluationIntervalSeconds` on every managed rule in the group:
 }
 ```
 
+Grafana stores the evaluation interval on the rule group rather than on each rule.
+Consequently, publishing an individual rule cannot preserve a migrated alert's native
+evaluation cadence unless the SDK also updates the containing group. The SDK treats the
+group as a unit so a cadence change cannot silently drop rules that were already present.
+
 The SDK removes this deployment-only field from the individual rule payload, then updates
 the complete Grafana rule group after all rules are published. Rules in the same group must
 specify the same positive interval. Omitting the field leaves the existing Grafana group


### PR DESCRIPTION
## Context

Migrates the three remaining Data Migration/KustoProcessor Azure-native alerts tracked by AB#12370 to managed Grafana. The definitions are present in both staging and production, following the repository's usual promotion pattern.

## Changes

- add staging and production `DataMigrationJobProcessingTimeInSeconds` coverage with a 5-minute Average `>300` threshold
- add staging and production `exceptions/server` coverage, preserving each environment's native window (30 minutes in staging and 15 minutes in production)
- add staging and production `MessageDelay` coverage, preserving each environment's native window (15 minutes in staging and 5 minutes in production) and Average `>6000` threshold
- route staging rules to non-paging Teams validation and production rules to DDFun IcM
- keep the production KustoProcessor rules paused to preserve the disabled state of their native counterparts until parity is proven
- add opt-in `evaluationIntervalSeconds` deployment support so Grafana rule-group cadence is explicitly set to the native 5-minute interval
- fail before publishing on mixed or conflicting group cadence declarations
- preserve and verify the complete rule set when replacing a Grafana rule group to update its interval

The enabled native Azure Monitor rules remain enabled until these definitions are deployed and validated from the production/staging Grafana data planes.

## Validation

- `dotnet test src/Monitoring/Microsoft.DotNet.Monitoring.Sdk.Tests/Microsoft.DotNet.Monitoring.Sdk.Tests.csproj --configuration Release --no-restore` (14 passed)
- `dotnet build src/Monitoring/Monitoring.DncEng/Monitoring.DncEng.proj --configuration Release --no-restore`
- paired staging and production alert definitions parse successfully and preserve the native source, threshold, and window semantics

AB#12370

<!-- pr-stack -->
## PR stack

Merge these PRs from top to bottom in this table. After a parent merges, retarget the next PR to `main`.

| Order | PR | Change |
| --- | --- | --- |
| 1 | [#6703](https://github.com/dotnet/dnceng/pull/6703) | Migrate Data Migration alerts to Grafana |
| 2 | [#6702](https://github.com/dotnet/dnceng/pull/6702) | Retire source.dot.net monitoring |
| 3 | [#6706](https://github.com/dotnet/dnceng/pull/6706) | Inventory V1 Grafana retirements in report-only mode |