### PR TITLE
Fix Grafana alert work item collisions

### DIFF
--- a/src/DotNet.Status.Web/DotNet.Status.Web.Tests/AlertHookControllerTests.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web.Tests/AlertHookControllerTests.cs
@@ -27,6 +27,7 @@ public class AlertHookControllerTests
             State = "alerting",
             Message = "Something went wrong",
             RuleUrl = "https://example/rule",
+            RuleId = 1,
             EvalMatches = null,
         };
 
@@ -86,6 +87,7 @@ public class AlertHookControllerTests
             State = "alerting",
             Message = "High CPU",
             RuleUrl = "https://example/rule",
+            RuleId = 1,
             EvalMatches = new List<GrafanaNotificationMatch>
             {
                 new GrafanaNotificationMatch { Metric = "cpu_usage", Value = 95.5 },
@@ -96,6 +98,129 @@ public class AlertHookControllerTests
 
         description.Should().Contain("cpu_usage");
         description.Should().Contain("95.5");
+    }
+
+    [Test]
+    public void GetUniqueIdentifier_WithLegacyTags_UsesNotificationId()
+    {
+        GrafanaNotification notification = new GrafanaNotification
+        {
+            RuleId = 1,
+            Tags = ImmutableDictionary<string, string>.Empty
+                .Add(AlertHookController.NotificationTagName, "legacy-notification"),
+        };
+
+        string identifier = AlertHookController.GetUniqueIdentifier(notification);
+
+        identifier.Should().Be("legacy-notification");
+    }
+
+    [Test]
+    public void GetUniqueIdentifier_WithUnifiedAlertLabels_UsesNotificationId()
+    {
+        GrafanaNotification notification = new GrafanaNotification
+        {
+            CommonLabels = ImmutableDictionary<string, string>.Empty
+                .Add(AlertHookController.NotificationTagName, "unified-notification"),
+        };
+
+        string identifier = AlertHookController.GetUniqueIdentifier(notification);
+
+        identifier.Should().Be("unified-notification");
+    }
+
+    [Test]
+    public void GetUniqueIdentifier_WithoutNotificationId_UsesRuleUid()
+    {
+        GrafanaNotification notification = new GrafanaNotification
+        {
+            CommonLabels = ImmutableDictionary<string, string>.Empty
+                .Add(AlertHookController.RuleUidLabelName, "rule-uid"),
+        };
+
+        string identifier = AlertHookController.GetUniqueIdentifier(notification);
+
+        identifier.Should().Be("rule-uid");
+    }
+
+    [Test]
+    public void GetUniqueIdentifier_WithAlertLabels_UsesNotificationId()
+    {
+        GrafanaNotification notification = new GrafanaNotification
+        {
+            Alerts = new List<GrafanaAlert>
+            {
+                new GrafanaAlert
+                {
+                    Labels = ImmutableDictionary<string, string>.Empty
+                        .Add(AlertHookController.NotificationTagName, "nested-notification"),
+                },
+            }.ToImmutableList(),
+        };
+
+        string identifier = AlertHookController.GetUniqueIdentifier(notification);
+
+        identifier.Should().Be("nested-notification");
+    }
+
+    [Test]
+    public void GetUniqueIdentifier_WithZeroRuleIdAndNoLabels_Throws()
+    {
+        GrafanaNotification notification = new GrafanaNotification();
+
+        Action action = () => AlertHookController.GetUniqueIdentifier(notification);
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*must provide*");
+    }
+
+    [Test]
+    public void GetUniqueIdentifier_WithConflictingNotificationIds_Throws()
+    {
+        GrafanaNotification notification = new GrafanaNotification
+        {
+            CommonLabels = ImmutableDictionary<string, string>.Empty
+                .Add(AlertHookController.NotificationTagName, "first-notification"),
+            Alerts = new List<GrafanaAlert>
+            {
+                new GrafanaAlert
+                {
+                    Labels = ImmutableDictionary<string, string>.Empty
+                        .Add(AlertHookController.NotificationTagName, "second-notification"),
+                },
+            }.ToImmutableList(),
+        };
+
+        Action action = () => AlertHookController.GetUniqueIdentifier(notification);
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*conflicting 'NotificationId' values*");
+    }
+
+    [Test]
+    public void GetUniqueIdentifier_WithMixedAlertIdentifiers_Throws()
+    {
+        GrafanaNotification notification = new GrafanaNotification
+        {
+            Alerts = new List<GrafanaAlert>
+            {
+                new GrafanaAlert
+                {
+                    Labels = ImmutableDictionary<string, string>.Empty
+                        .Add(AlertHookController.NotificationTagName, "notification-id"),
+                },
+                new GrafanaAlert
+                {
+                    Labels = ImmutableDictionary<string, string>.Empty
+                        .Add(AlertHookController.RuleUidLabelName, "rule-uid"),
+                },
+            }.ToImmutableList(),
+        };
+
+        Action action = () => AlertHookController.GetUniqueIdentifier(notification);
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*conflicting stable identifiers*");
     }
 
     private static AlertHookController CreateController()
@@ -124,4 +249,3 @@ public class AlertHookControllerTests
             NullLogger<AlertHookController>.Instance);
     }
 }
-

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/AlertHookController.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Controllers/AlertHookController.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -30,6 +31,7 @@ public class AlertHookController : ControllerBase
     public const string InactiveAlertTag = "Inactive Alert";
     public const string BodyLabelTextFormat = "Grafana-Automated-Alert-Id-{0}";
     public const string NotificationTagName = "NotificationId";
+    public const string RuleUidLabelName = "__alert_rule_uid__";
 
     private readonly IOptions<AzureDevOpsAlertOptions> _alertOptions;
     private readonly IOptions<GrafanaOptions> _grafanaOptions;
@@ -55,6 +57,16 @@ public class AlertHookController : ControllerBase
         {
             _logger.LogWarning("Unauthorized alert webhook request received");
             return Unauthorized();
+        }
+
+        try
+        {
+            GetUniqueIdentifier(notification);
+        }
+        catch (InvalidOperationException exception)
+        {
+            _logger.LogError(exception, "Grafana alert webhook does not contain a stable alert identifier");
+            return BadRequest(exception.Message);
         }
 
         switch (notification.State)
@@ -275,15 +287,87 @@ public class AlertHookController : ControllerBase
         };
     }
 
-    private static string GetUniqueIdentifier(GrafanaNotification notification)
+    internal static string GetUniqueIdentifier(GrafanaNotification notification)
     {
-        string id = null;
-        if (notification.Tags?.TryGetValue(NotificationTagName, out id) ?? false)
+        string notificationId = GetUniqueLabelValue(
+            NotificationTagName,
+            notification.Tags,
+            notification.CommonLabels,
+            notification.GroupLabels);
+        string ruleUid = GetUniqueLabelValue(
+            RuleUidLabelName,
+            notification.Tags,
+            notification.CommonLabels,
+            notification.GroupLabels);
+
+        if (notification.Alerts?.Count > 0)
         {
-            return id;
+            string[] alertIdentifiers = notification.Alerts
+                .Select(alert => ResolveIdentifier(
+                    GetUniqueLabelValue(NotificationTagName, notification.CommonLabels, notification.GroupLabels, alert.Labels),
+                    GetUniqueLabelValue(RuleUidLabelName, notification.CommonLabels, notification.GroupLabels, alert.Labels),
+                    notification.RuleId))
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+
+            if (alertIdentifiers.Length != 1)
+            {
+                throw new InvalidOperationException(
+                    "Grafana alert webhook contains alerts with conflicting stable identifiers.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(notificationId)
+                && !string.Equals(notificationId, alertIdentifiers[0], StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Grafana alert webhook contains conflicting '{NotificationTagName}' values.");
+            }
+
+            return alertIdentifiers[0];
         }
 
-        return notification.RuleId.ToString();
+        return ResolveIdentifier(notificationId, ruleUid, notification.RuleId);
+    }
+
+    private static string ResolveIdentifier(string notificationId, string ruleUid, ulong ruleId)
+    {
+        if (!string.IsNullOrWhiteSpace(notificationId))
+        {
+            return notificationId;
+        }
+
+        if (!string.IsNullOrWhiteSpace(ruleUid))
+        {
+            return ruleUid;
+        }
+
+        if (ruleId != 0)
+        {
+            return ruleId.ToString();
+        }
+
+        throw new InvalidOperationException(
+            $"Grafana alert webhook must provide '{NotificationTagName}', '{RuleUidLabelName}', or a nonzero RuleId.");
+    }
+
+    private static string GetUniqueLabelValue(
+        string labelName,
+        params ImmutableDictionary<string, string>[] labelSets)
+    {
+        string[] values = labelSets
+            .Where(labels => labels != null)
+            .Select(labels => labels.TryGetValue(labelName, out string value) ? value : null)
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        return values.Length switch
+        {
+            0 => null,
+            1 => values[0],
+            _ => throw new InvalidOperationException(
+                $"Grafana alert webhook contains conflicting '{labelName}' values."),
+        };
     }
 
     private static string BuildTagString(params string[] tags)

--- a/src/DotNet.Status.Web/DotNet.Status.Web/Models/GrafanaNotification.cs
+++ b/src/DotNet.Status.Web/DotNet.Status.Web/Models/GrafanaNotification.cs
@@ -17,4 +17,12 @@ public class GrafanaNotification
     public string Message { get; set; }
     public IImmutableList<GrafanaNotificationMatch> EvalMatches { get; set; }
     public ImmutableDictionary<string, string> Tags { get; set; }
+    public ImmutableDictionary<string, string> CommonLabels { get; set; }
+    public ImmutableDictionary<string, string> GroupLabels { get; set; }
+    public IImmutableList<GrafanaAlert> Alerts { get; set; }
+}
+
+public class GrafanaAlert
+{
+    public ImmutableDictionary<string, string> Labels { get; set; }
 }


### PR DESCRIPTION
## Summary

- read `NotificationId` from Grafana unified-alerting `commonLabels`, `groupLabels`, and nested alert labels while preserving legacy `tags` support
- fall back to `__alert_rule_uid__` or a nonzero legacy `RuleId`
- reject missing, conflicting, or mixed grouped-alert identifiers instead of creating or reopening `Grafana-Automated-Alert-Id-0`
- add regression coverage for legacy and unified payload shapes

## Root cause

`AlertHookController` only inspected the legacy `Tags` property. Unified Grafana webhooks did not populate it, and their legacy `RuleId` value was `0`. Unrelated alerts therefore queried for the same hidden automation identifier and repeatedly reopened AB#11051.

## Validation

- `dotnet test src/DotNet.Status.Web/DotNet.Status.Web.Tests/DotNet.Status.Web.Tests.csproj -p:RuntimeIdentifier=win-arm64 -p:SelfContained=false --filter FullyQualifiedName~AlertHookControllerTests`
- 11 tests passed

Tracking: https://dev.azure.com/dnceng/internal/_workitems/edit/12388