### PR TITLE
Add Teams-to-IcM Logic App pilot

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -206,6 +206,24 @@ extends:
                   }
                   Write-Host "SUCCESS: Bicep template validation successful"
 
+            - task: AzureCLI@2
+              displayName: 'Validate Teams-to-IcM Pilot Bicep Template'
+              inputs:
+                azureSubscription: '$(ServiceConnectionName)'
+                scriptType: 'ps'
+                scriptLocation: 'inlineScript'
+                inlineScript: |
+                  Write-Host "Validating Teams-to-IcM pilot Bicep template..."
+                  if (!(Test-Path "eng/deployment/teams-icm-pilot.bicep")) {
+                    throw "Bicep template not found: teams-icm-pilot.bicep"
+                  }
+
+                  az bicep build --file eng/deployment/teams-icm-pilot.bicep
+                  if ($LASTEXITCODE -ne 0) {
+                    throw "Bicep template validation failed"
+                  }
+                  Write-Host "SUCCESS: Bicep template validation successful"
+
     - template: /eng/common/templates-official/post-build/post-build.yml@self
       parameters:
         enableSymbolValidation: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -243,6 +243,54 @@ extends:
                     $workflow = Get-Content $_.FullName -Raw | ConvertFrom-Json
                     Test-HttpMethods $workflow.actions
                   }
+                  $operationalContext = Get-Content "eng/deployment/teams-icm-operational-context.json" -Raw | ConvertFrom-Json
+                  if (!$operationalContext.catalogVersion -or
+                      !$operationalContext.ownership.team -or
+                      !$operationalContext.ownership.service -or
+                      !$operationalContext.intakeRunbook.url -or
+                      !$operationalContext.fallbackPlaybook.url -or
+                      !$operationalContext.playbooks -or
+                      @($operationalContext.playbooks).Count -eq 0) {
+                    throw "Operational context catalog is missing required fields"
+                  }
+                  $fallback = $operationalContext.fallbackPlaybook
+                  if (!$fallback.name -or !$fallback.url -or !$fallback.selection -or
+                      !$fallback.remediationGuidance -or @($fallback.remediationGuidance).Count -eq 0 -or
+                      !$fallback.validationCriteria -or @($fallback.validationCriteria).Count -eq 0) {
+                    throw "Operational context catalog contains an incomplete fallback playbook"
+                  }
+                  $catalogLinks = @($operationalContext.intakeRunbook.url, $operationalContext.fallbackPlaybook.url)
+                  $catalogLinks += @($operationalContext.playbooks | ForEach-Object { $_.url })
+                  if (@($catalogLinks | Where-Object { $_ -notmatch '^https://' }).Count -gt 0) {
+                    throw "Operational context catalog contains a non-HTTPS link"
+                  }
+                  if (@($operationalContext.playbooks | Where-Object {
+                    !$_.id -or !$_.name -or !$_.url -or !$_.selection -or
+                    !$_.matchTerms -or @($_.matchTerms).Count -eq 0 -or @($_.matchTerms).Count -gt 4 -or
+                    !$_.remediationGuidance -or @($_.remediationGuidance).Count -eq 0 -or
+                    !$_.validationCriteria -or @($_.validationCriteria).Count -eq 0
+                  }).Count -gt 0) {
+                    throw "Operational context catalog contains an incomplete playbook"
+                  }
+                  function Select-OperationalPlaybook([string] $message) {
+                    $normalizedMessage = $message.ToLowerInvariant()
+                    foreach ($playbook in $operationalContext.playbooks) {
+                      foreach ($term in $playbook.matchTerms) {
+                        if ($normalizedMessage.Contains($term.ToLowerInvariant())) {
+                          return $playbook
+                        }
+                      }
+                    }
+                    return $operationalContext.fallbackPlaybook
+                  }
+                  $matchedPlaybook = Select-OperationalPlaybook "Please reimage this physical machine."
+                  if ($matchedPlaybook.id -ne "reimage-on-prem-machine") {
+                    throw "Operational context catalog did not match the reimaging playbook"
+                  }
+                  $fallbackPlaybook = Select-OperationalPlaybook "Investigate this unrelated customer request."
+                  if ($fallbackPlaybook.name -ne $operationalContext.fallbackPlaybook.name) {
+                    throw "Operational context catalog did not return its fallback playbook"
+                  }
                   if ($unsupportedMethods.Count -gt 0) {
                     throw "Workflow contains HTTP methods unsupported by Logic Apps: $($unsupportedMethods -join ', ')"
                   }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -222,6 +222,28 @@ extends:
                   if ($LASTEXITCODE -ne 0) {
                     throw "Bicep template validation failed"
                   }
+
+                  $workflow = Get-Content "eng/deployment/teams-icm-pilot.workflow.json" -Raw | ConvertFrom-Json
+                  $unsupportedMethods = @()
+                  function Test-HttpMethods($actions) {
+                    foreach ($property in $actions.PSObject.Properties) {
+                      $action = $property.Value
+                      if ($action.type -eq "Http" -and $action.inputs.method -notin @("GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS")) {
+                        $script:unsupportedMethods += "$($property.Name): $($action.inputs.method)"
+                      }
+                      if ($action.actions) {
+                        Test-HttpMethods $action.actions
+                      }
+                      if ($action.else.actions) {
+                        Test-HttpMethods $action.else.actions
+                      }
+                    }
+                  }
+                  Test-HttpMethods $workflow.actions
+                  if ($unsupportedMethods.Count -gt 0) {
+                    throw "Workflow contains HTTP methods unsupported by Logic Apps: $($unsupportedMethods -join ', ')"
+                  }
+
                   Write-Host "SUCCESS: Bicep template validation successful"
 
     - template: /eng/common/templates-official/post-build/post-build.yml@self

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -223,7 +223,6 @@ extends:
                     throw "Bicep template validation failed"
                   }
 
-                  $workflow = Get-Content "eng/deployment/teams-icm-pilot.workflow.json" -Raw | ConvertFrom-Json
                   $unsupportedMethods = @()
                   function Test-HttpMethods($actions) {
                     foreach ($property in $actions.PSObject.Properties) {
@@ -239,7 +238,11 @@ extends:
                       }
                     }
                   }
-                  Test-HttpMethods $workflow.actions
+                  Get-ChildItem "eng/deployment/teams-icm-*.workflow.json" | ForEach-Object {
+                    Write-Host "Validating workflow $($_.Name)..."
+                    $workflow = Get-Content $_.FullName -Raw | ConvertFrom-Json
+                    Test-HttpMethods $workflow.actions
+                  }
                   if ($unsupportedMethods.Count -gt 0) {
                     throw "Workflow contains HTTP methods unsupported by Logic Apps: $($unsupportedMethods -join ', ')"
                   }

--- a/eng/deployment/teams-icm-connector-adapter.workflow.json
+++ b/eng/deployment/teams-icm-connector-adapter.workflow.json
@@ -1,0 +1,237 @@
+{
+  "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "$connections": {
+      "defaultValue": {},
+      "type": "Object"
+    },
+    "processorCallbackUrl": {
+      "type": "SecureString"
+    },
+    "teamId": {
+      "type": "String"
+    },
+    "channelId": {
+      "type": "String"
+    },
+    "storageTableEndpoint": {
+      "type": "String"
+    },
+    "storageTableName": {
+      "type": "String"
+    }
+  },
+  "triggers": {
+    "Poll_Channel": {
+      "type": "Recurrence",
+      "recurrence": {
+        "frequency": "Second",
+        "interval": 15
+      },
+      "runtimeConfiguration": {
+        "concurrency": {
+          "runs": 1
+        }
+      }
+    }
+  },
+  "actions": {
+    "Compose_Window_End": {
+      "type": "Compose",
+      "inputs": "@utcNow()",
+      "runAfter": {}
+    },
+    "Get_Poll_State": {
+      "type": "Http",
+      "inputs": {
+        "authentication": {
+          "type": "ManagedServiceIdentity",
+          "audience": "https://storage.azure.com/"
+        },
+        "headers": {
+          "Accept": "application/json;odata=nometadata",
+          "x-ms-version": "2019-02-02"
+        },
+        "method": "GET",
+        "retryPolicy": {
+          "type": "exponential",
+          "count": 4,
+          "interval": "PT5S",
+          "minimumInterval": "PT5S",
+          "maximumInterval": "PT1M"
+        },
+        "uri": "@{concat(parameters('storageTableEndpoint'), parameters('storageTableName'), '()?$filter=', encodeUriComponent('PartitionKey eq ''TeamsIcmSystem'' and RowKey eq ''ChannelPoller'''))}"
+      },
+      "runAfter": {
+        "Compose_Window_End": [
+          "Succeeded"
+        ]
+      }
+    },
+    "Compose_Window_Start": {
+      "type": "Compose",
+      "inputs": "@if(empty(body('Get_Poll_State')?['value']), addHours(outputs('Compose_Window_End'), -1), first(body('Get_Poll_State')?['value'])?['LastSuccessfulPoll'])",
+      "runAfter": {
+        "Get_Poll_State": [
+          "Succeeded"
+        ]
+      }
+    },
+    "Get_Channel_Messages": {
+      "type": "ApiConnection",
+      "inputs": {
+        "host": {
+          "connection": {
+            "name": "@parameters('$connections')['teams']['connectionId']"
+          }
+        },
+        "method": "get",
+        "path": "/beta/teams/@{encodeURIComponent(parameters('teamId'))}/channels/@{encodeURIComponent(parameters('channelId'))}/messages"
+      },
+      "runtimeConfiguration": {
+        "paginationPolicy": {
+          "minimumItemCount": 100
+        }
+      },
+      "runAfter": {
+        "Compose_Window_Start": [
+          "Succeeded"
+        ]
+      }
+    },
+    "Filter_New_Root_Messages": {
+      "type": "Query",
+      "inputs": {
+        "from": "@coalesce(body('Get_Channel_Messages')?['value'], createArray())",
+        "where": "@and(equals(item()?['replyToId'], null), greater(ticks(item()?['createdDateTime']), ticks(outputs('Compose_Window_Start'))), lessOrEquals(ticks(item()?['createdDateTime']), ticks(outputs('Compose_Window_End'))))"
+      },
+      "runAfter": {
+        "Get_Channel_Messages": [
+          "Succeeded"
+        ]
+      }
+    },
+    "Process_New_Root_Messages": {
+      "type": "Foreach",
+      "foreach": "@body('Filter_New_Root_Messages')",
+      "operationOptions": "Sequential",
+      "actions": {
+        "Invoke_IcM_Processor": {
+          "type": "Http",
+          "inputs": {
+            "body": {
+              "message": "@item()"
+            },
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "method": "POST",
+            "retryPolicy": {
+              "type": "exponential",
+              "count": 4,
+              "interval": "PT5S",
+              "minimumInterval": "PT5S",
+              "maximumInterval": "PT1M"
+            },
+            "uri": "@parameters('processorCallbackUrl')"
+          },
+          "runAfter": {}
+        }
+      },
+      "runAfter": {
+        "Filter_New_Root_Messages": [
+          "Succeeded"
+        ]
+      }
+    },
+    "Record_Successful_Poll": {
+      "type": "If",
+      "expression": {
+        "equals": [
+          "@empty(body('Get_Poll_State')?['value'])",
+          true
+        ]
+      },
+      "actions": {
+        "Create_Poll_State": {
+          "type": "Http",
+          "inputs": {
+            "authentication": {
+              "type": "ManagedServiceIdentity",
+              "audience": "https://storage.azure.com/"
+            },
+            "body": {
+              "PartitionKey": "TeamsIcmSystem",
+              "RowKey": "ChannelPoller",
+              "LastSuccessfulPoll": "@{outputs('Compose_Window_End')}",
+              "TeamId": "@{parameters('teamId')}",
+              "ChannelId": "@{parameters('channelId')}",
+              "UpdatedAt": "@{utcNow()}"
+            },
+            "headers": {
+              "Accept": "application/json;odata=nometadata",
+              "Content-Type": "application/json",
+              "x-ms-date": "@{utcNow('R')}",
+              "x-ms-version": "2019-02-02"
+            },
+            "method": "POST",
+            "retryPolicy": {
+              "type": "exponential",
+              "count": 4,
+              "interval": "PT5S",
+              "minimumInterval": "PT5S",
+              "maximumInterval": "PT1M"
+            },
+            "uri": "@{concat(parameters('storageTableEndpoint'), parameters('storageTableName'))}"
+          },
+          "runAfter": {}
+        }
+      },
+      "else": {
+        "actions": {
+          "Update_Poll_State": {
+            "type": "Http",
+            "inputs": {
+              "authentication": {
+                "type": "ManagedServiceIdentity",
+                "audience": "https://storage.azure.com/"
+              },
+              "body": {
+                "PartitionKey": "TeamsIcmSystem",
+                "RowKey": "ChannelPoller",
+                "LastSuccessfulPoll": "@{outputs('Compose_Window_End')}",
+                "TeamId": "@{parameters('teamId')}",
+                "ChannelId": "@{parameters('channelId')}",
+                "UpdatedAt": "@{utcNow()}"
+              },
+              "headers": {
+                "Accept": "application/json;odata=nometadata",
+                "Content-Type": "application/json",
+                "If-Match": "*",
+                "x-ms-date": "@{utcNow('R')}",
+                "x-ms-version": "2019-02-02"
+              },
+              "method": "PUT",
+              "retryPolicy": {
+                "type": "exponential",
+                "count": 4,
+                "interval": "PT5S",
+                "minimumInterval": "PT5S",
+                "maximumInterval": "PT1M"
+              },
+              "uri": "@{concat(parameters('storageTableEndpoint'), parameters('storageTableName'), '(PartitionKey=''TeamsIcmSystem'',RowKey=''ChannelPoller'')')}"
+            },
+            "runAfter": {}
+          }
+        }
+      },
+      "runAfter": {
+        "Process_New_Root_Messages": [
+          "Succeeded"
+        ]
+      }
+    }
+  },
+  "outputs": {}
+}

--- a/eng/deployment/teams-icm-operational-context.json
+++ b/eng/deployment/teams-icm-operational-context.json
@@ -1,0 +1,46 @@
+{
+  "catalogVersion": "2026-09-03",
+  "ownership": {
+    "team": "DDFun Customer Requests",
+    "service": "DDFun Services Management"
+  },
+  "intakeRunbook": {
+    "name": "Creating IcM incidents for DDFun customer requests",
+    "url": "https://dnceng.visualstudio.com/internal/_wiki/wikis/DNCEng%20Services%20Wiki/1579/creating-icm-incidents-for-ddfun-customer-requests"
+  },
+  "fallbackPlaybook": {
+    "name": "DDFun customer request intake",
+    "url": "https://dnceng.visualstudio.com/internal/_wiki/wikis/DNCEng%20Services%20Wiki/1579/creating-icm-incidents-for-ddfun-customer-requests",
+    "selection": "Fallback: no specific vendor playbook matched the Teams message.",
+    "remediationGuidance": [
+      "Investigate the reported issue using the evidence in the originating Teams thread.",
+      "Record the remediation or final disposition in the IcM."
+    ],
+    "validationCriteria": [
+      "Confirm the reported customer impact is mitigated.",
+      "Document the completed remediation or disposition before resolving the IcM."
+    ]
+  },
+  "playbooks": [
+    {
+      "id": "reimage-on-prem-machine",
+      "name": "Reimaging On-Prem Machines",
+      "url": "https://dnceng.visualstudio.com/internal/_wiki/wikis/DNCEng%20Services%20Wiki/2327/DDFUN-Vendor-Playbooks/Reimaging-On-Prem-Machines",
+      "matchTerms": [
+        "reimage",
+        "physical machine",
+        "on-prem machine",
+        "on prem machine"
+      ],
+      "selection": "Matched from physical-machine or reimaging language in the Teams message.",
+      "remediationGuidance": [
+        "Quarantine the affected machine before remediation.",
+        "Follow the linked playbook to reimage or repair the machine."
+      ],
+      "validationCriteria": [
+        "Validate the machine after remediation.",
+        "Return it to service only after the reported failure no longer reproduces."
+      ]
+    }
+  ]
+}

--- a/eng/deployment/teams-icm-pilot.README.md
+++ b/eng/deployment/teams-icm-pilot.README.md
@@ -123,6 +123,65 @@ adapter and watermark but preserves the Teams connection, message-ID reservation
 idempotency keys, Table state transitions, and reply behavior. Its documented trade-off is a
 fixed polling latency of up to approximately three minutes.
 
+## Production rollout plan
+
+The MVP uses a user-authorized Teams connection in a test channel. Do not treat that connection
+or the pilot resource group as the production deployment.
+
+1. **Replace the personal connection identity.**
+   - Create a dedicated Entra application and service principal for the automation.
+   - Grant only the permissions required to read the selected channel and post thread replies.
+   - Confirm that the Teams managed connector supports the intended service-principal
+     authentication flow. This is a rollout gate: if it does not, select an approved non-personal
+     identity mechanism rather than retaining an individual operator's connection.
+   - Scope the ICM Provider authorization to only
+     `POST /api/mi/AddOrUpdateIcmIncident`, and confirm the production principal is the identity
+     authorized by the provider.
+
+2. **Create the production intake channel.**
+   - Create a dedicated channel in the `Partners` Team.
+   - Agree on the channel name, channel type, owners, membership, retention, and posting guidance
+     before creation.
+   - Record the production Team and channel IDs and supply them as deployment parameters; do not
+     replace the test defaults without peer review.
+
+3. **Provision production separately.**
+   - Use a production resource group, storage account, Table, Log Analytics workspace, action
+     group, Teams connection, processor, and polling adapter.
+   - Deploy both workflows disabled.
+   - Authorize the non-personal Teams connection, apply the Table role assignments, deploy the
+     endpoint-scoped ICM Provider authorization, and confirm the connection reports `Connected`.
+   - Confirm failed-run diagnostics and alert recipients before enabling intake.
+
+4. **Run a controlled rollout.**
+   - Enable the processor and poller during an attended rollout window.
+   - Post one clearly labeled Sev4 root-thread test in the new channel.
+   - Measure message-to-IcM latency and verify exactly one correctly routed DDFun incident, one
+     originating-thread reply, durable `ReplyPosted` state, and no incident from replies.
+   - Resolve the test incident immediately.
+   - Observe polling runs, connector throttling, Table state, processor failures, and alert
+     delivery before announcing general availability.
+
+5. **Complete the code and authorization rollout.**
+   - Merge and deploy the endpoint-scoped ICM Provider authorization.
+   - Review and merge the dnceng deployment change.
+   - Publish operator ownership, support escalation, monitoring, and rollback instructions.
+   - If short-interval polling is not reliable, restore the fixed three-minute connector trigger
+     without changing processor or idempotency state.
+
+6. **Remove all test resources after production acceptance.**
+   - Resolve any remaining test incidents and remove or archive the test Teams channel as agreed
+     with its owners.
+   - Delete the `dnceng-teams-icm-pilot` resource group, including its Logic Apps, API connection,
+     storage account and Table data, Log Analytics workspace, action group, alerts, and role
+     assignments.
+   - Remove the pilot identity from the ICM Provider allowlist and delete any remaining pilot
+     Entra objects or consent grants.
+   - Confirm that no scheduled workflow, alert, diagnostic setting, generated package, or local
+     test artifact remains.
+   - The previously deleted purge-protected Graph experiment Key Vault cannot be purged before
+     retention expiry; verify that it remains deleted and allow Azure retention to expire.
+
 The Test ICM Provider creates real production IcM incidents. Use only controlled Sev4 test
 messages, verify routing to `DDFUNSERVICESMANAGEMENT\DDFuncustomerrequests`, and resolve every
 test incident promptly.

--- a/eng/deployment/teams-icm-pilot.README.md
+++ b/eng/deployment/teams-icm-pilot.README.md
@@ -34,6 +34,13 @@ Severity: 3 or 4
 The connector and routing rule are fixed in the deployment. Teams content cannot select an IcM
 destination, and the workflow rejects severities other than 3 or 4.
 
+The processor also loads `teams-icm-operational-context.json`, a versioned catalog of DDFun
+ownership, intake guidance, playbook matching signals, remediation guidance, validation criteria,
+and canonical links. Physical-machine or reimaging language selects the Reimaging On-Prem
+Machines playbook. Messages without a specific match use the DDFun intake runbook as an explicit
+fallback; a missing match never prevents incident creation. Every incident records the catalog
+version used to compose its operational context.
+
 The workflow reserves each message with a Table Storage `POST`, then records state transitions
 with full-entity `PUT` updates. Keep every persisted field in each replacement body; the Logic Apps
 HTTP action does not support Table Storage's `MERGE` verb.

--- a/eng/deployment/teams-icm-pilot.README.md
+++ b/eng/deployment/teams-icm-pilot.README.md
@@ -1,9 +1,14 @@
 # Teams-to-IcM pilot
 
 This deployment implements the AB#12383 pilot for the `.NET Eng Services` Team and the
-`IcM Intake Automation Test` channel. It creates a disabled-by-default Consumption Logic App,
-a user-authorized Teams connection, durable Azure Table state, managed-identity access to that
-state, and failed-run monitoring.
+`IcM Intake Automation Test` channel. It creates disabled-by-default Consumption Logic Apps,
+a user-authorized Teams connection, durable Azure Table state, managed identities, and
+failed-run monitoring.
+
+The deployment uses a 15-second Logic Apps recurrence and the user-authorized Teams connector's
+`Get messages in a channel` action. This avoids the connector trigger's fixed three-minute
+polling interval while preserving one IcM for every new root thread without requiring an
+`@mention`, custom Teams app, tenant-wide Graph permission, or resource-specific consent (RSC).
 
 The workflow accepts root channel messages only. For a normal free-form post, it maps the Teams
 subject to the IcM title, the message body to impact and description, the sender to reporter, and
@@ -32,6 +37,29 @@ destination, and the workflow rejects severities other than 3 or 4.
 The workflow reserves each message with a Table Storage `POST`, then records state transitions
 with full-entity `PUT` updates. Keep every persisted field in each replacement body; the Logic Apps
 HTTP action does not support Table Storage's `MERGE` verb.
+
+## Intake architecture
+
+The deployment separates intake adapters from the processor:
+
+```text
+15-second recurrence
+  -> dnceng-teams-icm-pilot-connector
+       - reads up to 100 channel messages through the Teams connector
+       - selects root threads newer than its durable watermark
+       - advances the watermark only after all selected messages succeed
+  -> dnceng-teams-icm-pilot
+       - reserves the message ID in Azure Table Storage
+       - extracts structured or free-form intake
+       - creates the DDFun IcM
+       - replies in the originating thread
+```
+
+The poller stores `LastSuccessfulPoll` in the `TeamsIcmSystem` / `ChannelPoller` Table entity. On
+first deployment it looks back one hour. Each run uses its start time as the closed upper bound,
+processes matching root messages sequentially, and writes the new watermark only after every
+processor invocation succeeds. Overlapping reads are safe because the processor independently
+reserves each Teams message ID.
 
 ## Deploy safely
 
@@ -71,6 +99,29 @@ Deploy with `workflowEnabled=false`. Before enabling the workflow:
    identity.
 3. Confirm the Teams connection reports `Connected`.
 4. Enable the workflow with a second deployment using `workflowEnabled=true`.
+
+### Enable polling
+
+```powershell
+az deployment group create `
+  --subscription a4fc5514-21a9-4296-bfaf-5c7ee7fa35d1 `
+  --resource-group dnceng-teams-icm-pilot `
+  --template-file eng/deployment/teams-icm-pilot.bicep `
+  --parameters alertEmail=<pilot-owner-email> `
+               workflowEnabled=true
+```
+
+This enables both the poller and processor. The poller uses the same authorized Teams connection
+for channel reads that the processor uses for thread replies.
+
+### Revert to the fixed connector trigger
+
+The previous implementation used the Teams connector's `When a new channel message is added`
+trigger directly on the processor. It remains the rollback option if the 15-second recurrence
+causes sustained throttling or reliability problems. Restoring that trigger removes the polling
+adapter and watermark but preserves the Teams connection, message-ID reservations, IcM
+idempotency keys, Table state transitions, and reply behavior. Its documented trade-off is a
+fixed polling latency of up to approximately three minutes.
 
 The Test ICM Provider creates real production IcM incidents. Use only controlled Sev4 test
 messages, verify routing to `DDFUNSERVICESMANAGEMENT\DDFuncustomerrequests`, and resolve every

--- a/eng/deployment/teams-icm-pilot.README.md
+++ b/eng/deployment/teams-icm-pilot.README.md
@@ -22,6 +22,10 @@ Severity: 3 or 4
 The connector and routing rule are fixed in the deployment. Teams content cannot select an IcM
 destination, and the workflow rejects severities other than 3 or 4.
 
+The workflow reserves each message with a Table Storage `POST`, then records state transitions
+with full-entity `PUT` updates. Keep every persisted field in each replacement body; the Logic Apps
+HTTP action does not support Table Storage's `MERGE` verb.
+
 ## Deploy safely
 
 Validate the templates:

--- a/eng/deployment/teams-icm-pilot.README.md
+++ b/eng/deployment/teams-icm-pilot.README.md
@@ -1,0 +1,66 @@
+# Teams-to-IcM pilot
+
+This deployment implements the AB#12383 pilot for the `.NET Eng Services` Team and the
+`IcM Intake Automation Test` channel. It creates a disabled-by-default Consumption Logic App,
+a user-authorized Teams connection, durable Azure Table state, managed-identity access to that
+state, and failed-run monitoring.
+
+The workflow accepts root channel messages only. A request must use this exact field order and
+must provide a non-empty value for every field:
+
+```text
+Title:
+Who/customer affected:
+Impact:
+Affected service/infrastructure:
+Evidence or build/job URL:
+Requested action:
+Reporter:
+Severity: 3 or 4
+```
+
+The connector and routing rule are fixed in the deployment. Teams content cannot select an IcM
+destination, and the workflow rejects severities other than 3 or 4.
+
+## Deploy safely
+
+Validate the templates:
+
+```powershell
+az bicep build --file eng/deployment/teams-icm-pilot.bicep
+```
+
+Create the resource group and preview the deployment:
+
+```powershell
+az group create `
+  --subscription a4fc5514-21a9-4296-bfaf-5c7ee7fa35d1 `
+  --name dnceng-teams-icm-pilot `
+  --location westus2
+
+az deployment group what-if `
+  --subscription a4fc5514-21a9-4296-bfaf-5c7ee7fa35d1 `
+  --resource-group dnceng-teams-icm-pilot `
+  --template-file eng/deployment/teams-icm-pilot.bicep `
+  --parameters alertEmail=<pilot-owner-email>
+```
+
+Deploy with `workflowEnabled=false`. Before enabling the workflow:
+
+1. Resolve the Logic App identity's Application (client) ID from the `logicAppPrincipalId`
+   deployment output, add that Application ID to the ICM Provider Test managed-identity caller
+   allowlist, and deploy the provider:
+
+   ```powershell
+   az ad sp show --id <logicAppPrincipalId> --query appId --output tsv
+   ```
+
+   The ICM Provider authorizes the token's `appid`/`azp` claim, not the service principal object ID.
+2. Authorize the `dnceng-teams-icm-pilot-teams` API connection with the pilot operator's Teams
+   identity.
+3. Confirm the Teams connection reports `Connected`.
+4. Enable the workflow with a second deployment using `workflowEnabled=true`.
+
+The Test ICM Provider creates real production IcM incidents. Use only controlled Sev4 test
+messages, verify routing to `DDFUNSERVICESMANAGEMENT\DDFuncustomerrequests`, and resolve every
+test incident promptly.

--- a/eng/deployment/teams-icm-pilot.README.md
+++ b/eng/deployment/teams-icm-pilot.README.md
@@ -5,8 +5,15 @@ This deployment implements the AB#12383 pilot for the `.NET Eng Services` Team a
 a user-authorized Teams connection, durable Azure Table state, managed-identity access to that
 state, and failed-run monitoring.
 
-The workflow accepts root channel messages only. A request must use this exact field order and
-must provide a non-empty value for every field:
+The workflow accepts root channel messages only. For a normal free-form post, it maps the Teams
+subject to the IcM title, the message body to impact and description, the sender to reporter, and
+the Teams message link to evidence. Missing customer and infrastructure details use `Not specified`,
+the requested action defaults to `Investigate the reported issue`, and severity defaults to 4.
+Writing `Sev3`, `Sev 3`, or `Severity 3` in the message selects severity 3.
+Other or missing severity text defaults to Sev4; it never creates Sev1 or Sev2.
+
+Customers can optionally override every inferred value by using this exact field order with a
+non-empty value for every field:
 
 ```text
 Title:

--- a/eng/deployment/teams-icm-pilot.bicep
+++ b/eng/deployment/teams-icm-pilot.bicep
@@ -42,6 +42,7 @@ var teamsManagedApiId = subscriptionResourceId(
 var storageTableDataContributorRoleId = '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'
 var workflowDefinition = loadJsonContent('teams-icm-pilot.workflow.json')
 var connectorAdapterDefinition = loadJsonContent('teams-icm-connector-adapter.workflow.json')
+var operationalContext = loadJsonContent('teams-icm-operational-context.json')
 var connectorAdapterName = '${resourcePrefix}-connector'
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
@@ -142,6 +143,9 @@ resource logicApp 'Microsoft.Logic/workflows@2019-05-01' = {
       }
       icmRoutingRuleId: {
         value: icmRoutingRuleId
+      }
+      operationalContext: {
+        value: operationalContext
       }
     }
   }

--- a/eng/deployment/teams-icm-pilot.bicep
+++ b/eng/deployment/teams-icm-pilot.bicep
@@ -1,0 +1,273 @@
+@description('Azure region for the pilot resources and managed connector.')
+param location string = resourceGroup().location
+
+@description('Name of the Consumption Logic App.')
+param logicAppName string = 'dnceng-teams-icm-pilot'
+
+@description('Name of the user-authorized Microsoft Teams API connection.')
+param teamsConnectionName string = 'dnceng-teams-icm-pilot-teams'
+
+@description('Whether the workflow is enabled. Keep false until the Teams connection and ICM Provider allowlist are ready.')
+param workflowEnabled bool = false
+
+@description('Email address that receives failed-run alerts.')
+param alertEmail string
+
+@description('ID of the Team monitored by the pilot.')
+param teamId string = '147df318-61de-4f04-8f7b-ecd328c256bb'
+
+@description('ID of the channel monitored by the pilot.')
+param channelId string = '19:08a2d1fec9724517bdd595ac88176ff2@thread.skype'
+
+@description('Managed-identity endpoint for the ICM Provider.')
+param icmProviderEndpoint string = 'https://icmprovidernew-test.azurewebsites.net/api/mi/AddOrUpdateIcmIncident'
+
+@description('Entra audience used to call the ICM Provider.')
+param icmProviderAudience string = 'api://c12184db-8443-4228-8236-39f60fb104d7'
+
+@description('DDFun ICM service connector ID.')
+param icmConnectorId string = '9bfe0f4f-4dcf-4033-94a3-f463e90baf04'
+
+@description('Routing rule on the DDFun connector. This is not the display name.')
+param icmRoutingRuleId string = 'DDFUNCustomerRequests'
+
+var resourcePrefix = 'dnceng-teams-icm-pilot'
+var storageAccountName = 'dncengicm${uniqueString(subscription().id, resourceGroup().id)}'
+var storageTableName = 'TeamsIcmIntake'
+var teamsManagedApiId = subscriptionResourceId(
+  'Microsoft.Web/locations/managedApis',
+  location,
+  'teams'
+)
+var storageTableDataContributorRoleId = '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'
+var workflowDefinition = loadJsonContent('teams-icm-pilot.workflow.json')
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: storageAccountName
+  location: location
+  tags: {
+    Environment: 'Pilot'
+    Purpose: 'Teams to IcM durable idempotency'
+    Service: 'DncEng'
+    WorkItem: '12383'
+  }
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    allowBlobPublicAccess: false
+    allowCrossTenantReplication: false
+    defaultToOAuthAuthentication: true
+    minimumTlsVersion: 'TLS1_2'
+    publicNetworkAccess: 'Enabled'
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+resource tableService 'Microsoft.Storage/storageAccounts/tableServices@2023-05-01' = {
+  parent: storageAccount
+  name: 'default'
+}
+
+resource intakeTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2023-05-01' = {
+  parent: tableService
+  name: storageTableName
+}
+
+resource teamsConnection 'Microsoft.Web/connections@2016-06-01' = {
+  name: teamsConnectionName
+  location: location
+  tags: {
+    Environment: 'Pilot'
+    Purpose: 'Teams to IcM trigger and reply'
+    Service: 'DncEng'
+    WorkItem: '12383'
+  }
+  properties: {
+    api: {
+      id: teamsManagedApiId
+    }
+    displayName: teamsConnectionName
+  }
+}
+
+resource logicApp 'Microsoft.Logic/workflows@2019-05-01' = {
+  name: logicAppName
+  location: location
+  tags: {
+    Environment: 'Pilot'
+    Purpose: 'Teams to IcM intake automation'
+    Service: 'DncEng'
+    WorkItem: '12383'
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    state: workflowEnabled ? 'Enabled' : 'Disabled'
+    definition: workflowDefinition
+    parameters: {
+      '$connections': {
+        value: {
+          teams: {
+            connectionId: teamsConnection.id
+            connectionName: teamsConnection.name
+            id: teamsManagedApiId
+          }
+        }
+      }
+      storageTableEndpoint: {
+        value: storageAccount.properties.primaryEndpoints.table
+      }
+      storageTableName: {
+        value: intakeTable.name
+      }
+      teamId: {
+        value: teamId
+      }
+      channelId: {
+        value: channelId
+      }
+      icmProviderEndpoint: {
+        value: icmProviderEndpoint
+      }
+      icmProviderAudience: {
+        value: icmProviderAudience
+      }
+      icmConnectorId: {
+        value: icmConnectorId
+      }
+      icmRoutingRuleId: {
+        value: icmRoutingRuleId
+      }
+    }
+  }
+}
+
+resource storageTableDataContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, logicApp.id, storageTableDataContributorRoleId)
+  scope: storageAccount
+  properties: {
+    principalId: logicApp.identity.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      storageTableDataContributorRoleId
+    )
+  }
+}
+
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: '${resourcePrefix}-logs'
+  location: location
+  tags: {
+    Environment: 'Pilot'
+    Purpose: 'Teams to IcM monitoring'
+    Service: 'DncEng'
+    WorkItem: '12383'
+  }
+  properties: {
+    features: {
+      enableLogAccessUsingOnlyResourcePermissions: true
+    }
+    publicNetworkAccessForIngestion: 'Enabled'
+    publicNetworkAccessForQuery: 'Enabled'
+    retentionInDays: 30
+    sku: {
+      name: 'PerGB2018'
+    }
+  }
+}
+
+resource workflowDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'send-to-log-analytics'
+  scope: logicApp
+  properties: {
+    workspaceId: logAnalytics.id
+    logs: [
+      {
+        categoryGroup: 'allLogs'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
+  }
+}
+
+resource failureActionGroup 'Microsoft.Insights/actionGroups@2023-01-01' = {
+  name: '${resourcePrefix}-failures'
+  location: 'global'
+  tags: {
+    Environment: 'Pilot'
+    Purpose: 'Teams to IcM failed-run notifications'
+    Service: 'DncEng'
+    WorkItem: '12383'
+  }
+  properties: {
+    enabled: true
+    groupShortName: 'IcmPilot'
+    emailReceivers: [
+      {
+        name: 'Pilot owner'
+        emailAddress: alertEmail
+        useCommonAlertSchema: true
+      }
+    ]
+  }
+}
+
+resource failedRunsAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
+  name: '${resourcePrefix}-failed-runs'
+  location: 'global'
+  tags: {
+    Environment: 'Pilot'
+    Purpose: 'Teams to IcM failed-run detection'
+    Service: 'DncEng'
+    WorkItem: '12383'
+  }
+  properties: {
+    actions: [
+      {
+        actionGroupId: failureActionGroup.id
+      }
+    ]
+    autoMitigate: true
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          criterionType: 'StaticThresholdCriterion'
+          metricName: 'RunsFailed'
+          metricNamespace: 'Microsoft.Logic/workflows'
+          name: 'Failed workflow runs'
+          operator: 'GreaterThan'
+          threshold: 0
+          timeAggregation: 'Total'
+        }
+      ]
+    }
+    description: 'Alerts when a Teams-to-IcM pilot workflow run fails.'
+    enabled: true
+    evaluationFrequency: 'PT5M'
+    scopes: [
+      logicApp.id
+    ]
+    severity: 2
+    targetResourceRegion: location
+    targetResourceType: 'Microsoft.Logic/workflows'
+    windowSize: 'PT5M'
+  }
+}
+
+output logicAppName string = logicApp.name
+output logicAppPrincipalId string = logicApp.identity.principalId
+output storageAccountName string = storageAccount.name
+output storageTableName string = intakeTable.name
+output teamsConnectionId string = teamsConnection.id
+output workflowEnabled bool = workflowEnabled

--- a/eng/deployment/teams-icm-pilot.bicep
+++ b/eng/deployment/teams-icm-pilot.bicep
@@ -41,6 +41,8 @@ var teamsManagedApiId = subscriptionResourceId(
 )
 var storageTableDataContributorRoleId = '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'
 var workflowDefinition = loadJsonContent('teams-icm-pilot.workflow.json')
+var connectorAdapterDefinition = loadJsonContent('teams-icm-connector-adapter.workflow.json')
+var connectorAdapterName = '${resourcePrefix}-connector'
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   name: storageAccountName
@@ -80,7 +82,7 @@ resource teamsConnection 'Microsoft.Web/connections@2016-06-01' = {
   location: location
   tags: {
     Environment: 'Pilot'
-    Purpose: 'Teams to IcM trigger and reply'
+    Purpose: 'Teams to IcM channel read and reply'
     Service: 'DncEng'
     WorkItem: '12383'
   }
@@ -97,7 +99,7 @@ resource logicApp 'Microsoft.Logic/workflows@2019-05-01' = {
   location: location
   tags: {
     Environment: 'Pilot'
-    Purpose: 'Teams to IcM intake automation'
+    Purpose: 'Teams to IcM message processor'
     Service: 'DncEng'
     WorkItem: '12383'
   }
@@ -145,11 +147,68 @@ resource logicApp 'Microsoft.Logic/workflows@2019-05-01' = {
   }
 }
 
+resource connectorAdapter 'Microsoft.Logic/workflows@2019-05-01' = {
+  name: connectorAdapterName
+  location: location
+  tags: {
+    Environment: 'Pilot'
+    Purpose: 'Short-interval Teams channel polling'
+    Service: 'DncEng'
+    WorkItem: '12383'
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    state: workflowEnabled ? 'Enabled' : 'Disabled'
+    definition: connectorAdapterDefinition
+    parameters: {
+      '$connections': {
+        value: {
+          teams: {
+            connectionId: teamsConnection.id
+            connectionName: teamsConnection.name
+            id: teamsManagedApiId
+          }
+        }
+      }
+      processorCallbackUrl: {
+        value: listCallbackUrl('${logicApp.id}/triggers/Process_Teams_Message', '2019-05-01').value
+      }
+      teamId: {
+        value: teamId
+      }
+      channelId: {
+        value: channelId
+      }
+      storageTableEndpoint: {
+        value: storageAccount.properties.primaryEndpoints.table
+      }
+      storageTableName: {
+        value: intakeTable.name
+      }
+    }
+  }
+}
+
 resource storageTableDataContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(storageAccount.id, logicApp.id, storageTableDataContributorRoleId)
   scope: storageAccount
   properties: {
     principalId: logicApp.identity.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      storageTableDataContributorRoleId
+    )
+  }
+}
+
+resource connectorStorageTableDataContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, connectorAdapter.id, storageTableDataContributorRoleId)
+  scope: storageAccount
+  properties: {
+    principalId: connectorAdapter.identity.principalId
     principalType: 'ServicePrincipal'
     roleDefinitionId: subscriptionResourceId(
       'Microsoft.Authorization/roleDefinitions',
@@ -183,6 +242,26 @@ resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
 resource workflowDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
   name: 'send-to-log-analytics'
   scope: logicApp
+  properties: {
+    workspaceId: logAnalytics.id
+    logs: [
+      {
+        categoryGroup: 'allLogs'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
+  }
+}
+
+resource connectorAdapterDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'send-to-log-analytics'
+  scope: connectorAdapter
   properties: {
     workspaceId: logAnalytics.id
     logs: [
@@ -265,8 +344,52 @@ resource failedRunsAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
   }
 }
 
+resource connectorAdapterFailedRunsAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
+  name: '${connectorAdapterName}-failed-runs'
+  location: 'global'
+  tags: {
+    Environment: 'Pilot'
+    Purpose: 'Teams connector adapter failed-run detection'
+    Service: 'DncEng'
+    WorkItem: '12383'
+  }
+  properties: {
+    actions: [
+      {
+        actionGroupId: failureActionGroup.id
+      }
+    ]
+    autoMitigate: true
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          criterionType: 'StaticThresholdCriterion'
+          metricName: 'RunsFailed'
+          metricNamespace: 'Microsoft.Logic/workflows'
+          name: 'Failed connector adapter runs'
+          operator: 'GreaterThan'
+          threshold: 0
+          timeAggregation: 'Total'
+        }
+      ]
+    }
+    description: 'Alerts when the Teams channel polling adapter fails.'
+    enabled: true
+    evaluationFrequency: 'PT5M'
+    scopes: [
+      connectorAdapter.id
+    ]
+    severity: 2
+    targetResourceRegion: location
+    targetResourceType: 'Microsoft.Logic/workflows'
+    windowSize: 'PT5M'
+  }
+}
+
 output logicAppName string = logicApp.name
 output logicAppPrincipalId string = logicApp.identity.principalId
+output connectorAdapterName string = connectorAdapter.name
 output storageAccountName string = storageAccount.name
 output storageTableName string = intakeTable.name
 output teamsConnectionId string = teamsConnection.id

--- a/eng/deployment/teams-icm-pilot.workflow.json
+++ b/eng/deployment/teams-icm-pilot.workflow.json
@@ -29,6 +29,9 @@
     },
     "icmRoutingRuleId": {
       "type": "String"
+    },
+    "operationalContext": {
+      "type": "Object"
     }
   },
   "triggers": {
@@ -234,6 +237,27 @@
       "inputs": "@take(if(empty(trim(string(outputs('Compose_Message')?['subject']))), trim(first(split(outputs('Compose_Raw_Plain_Text'), decodeUriComponent('%0A')))), trim(string(outputs('Compose_Message')?['subject']))), 200)",
       "runAfter": {
         "Compose_Raw_Plain_Text": [
+          "Succeeded"
+        ]
+      }
+    },
+    "Filter_Matching_Playbooks": {
+      "type": "Query",
+      "inputs": {
+        "from": "@parameters('operationalContext')?['playbooks']",
+        "where": "@or(contains(toLower(outputs('Compose_Raw_Plain_Text')), toLower(coalesce(item()?['matchTerms']?[0], '__no_match__'))), contains(toLower(outputs('Compose_Raw_Plain_Text')), toLower(coalesce(item()?['matchTerms']?[1], '__no_match__'))), contains(toLower(outputs('Compose_Raw_Plain_Text')), toLower(coalesce(item()?['matchTerms']?[2], '__no_match__'))), contains(toLower(outputs('Compose_Raw_Plain_Text')), toLower(coalesce(item()?['matchTerms']?[3], '__no_match__'))))"
+      },
+      "runAfter": {
+        "Compose_Raw_Plain_Text": [
+          "Succeeded"
+        ]
+      }
+    },
+    "Compose_Selected_Playbook": {
+      "type": "Compose",
+      "inputs": "@if(empty(body('Filter_Matching_Playbooks')), parameters('operationalContext')?['fallbackPlaybook'], first(body('Filter_Matching_Playbooks')))",
+      "runAfter": {
+        "Filter_Matching_Playbooks": [
           "Succeeded"
         ]
       }
@@ -529,7 +553,7 @@
       "actions": {
         "Compose_IcM_Description": {
           "type": "Compose",
-          "inputs": "@concat('Created from a ', if(outputs('Compose_Is_Structured'), 'structured', 'free-form'), ' root message in the .NET Eng Services Teams IcM intake channel.', decodeUriComponent('%0A%0A'), if(outputs('Compose_Is_Structured'), '', concat('Original Teams message:', decodeUriComponent('%0A'), outputs('Compose_Raw_Plain_Text'), decodeUriComponent('%0A%0A'))), 'Impact: ', outputs('Compose_Impact'), decodeUriComponent('%0A'), 'Affected service/infrastructure: ', outputs('Compose_Affected_Infrastructure'), decodeUriComponent('%0A'), 'Evidence: ', outputs('Compose_Evidence'), decodeUriComponent('%0A'), 'Requested action: ', outputs('Compose_Requested_Action'), decodeUriComponent('%0A%0A'), '---', decodeUriComponent('%0A'), 'Incident Details (4W)', decodeUriComponent('%0A'), 'Who: ', outputs('Compose_Who'), decodeUriComponent('%0A'), 'What: ', outputs('Compose_Impact'), decodeUriComponent('%0A'), 'When: Teams message posted at ', outputs('Compose_Message')?['createdDateTime'], decodeUriComponent('%0A'), 'Where: ', outputs('Compose_Affected_Infrastructure'), decodeUriComponent('%0A%0A'), 'Filing Info', decodeUriComponent('%0A'), 'Filed by: ', outputs('Compose_Reporter'), decodeUriComponent('%0A'), 'Filing method: DncEng Teams IcM Logic App pilot', decodeUriComponent('%0A'), 'Teams message ID: ', outputs('Compose_Message')?['id'])"
+          "inputs": "@concat('Created from a ', if(outputs('Compose_Is_Structured'), 'structured', 'free-form'), ' root message in the .NET Eng Services Teams IcM intake channel.', decodeUriComponent('%0A%0A'), if(outputs('Compose_Is_Structured'), '', concat('Original Teams message:', decodeUriComponent('%0A'), outputs('Compose_Raw_Plain_Text'), decodeUriComponent('%0A%0A'))), 'Impact: ', outputs('Compose_Impact'), decodeUriComponent('%0A'), 'Affected service/infrastructure: ', outputs('Compose_Affected_Infrastructure'), decodeUriComponent('%0A'), 'Evidence: ', outputs('Compose_Evidence'), decodeUriComponent('%0A'), 'Requested action: ', outputs('Compose_Requested_Action'), decodeUriComponent('%0A%0A'), '---', decodeUriComponent('%0A'), 'Incident Details (4W)', decodeUriComponent('%0A'), 'Who: ', outputs('Compose_Who'), decodeUriComponent('%0A'), 'What: ', outputs('Compose_Impact'), decodeUriComponent('%0A'), 'When: Teams message posted at ', outputs('Compose_Message')?['createdDateTime'], decodeUriComponent('%0A'), 'Where: ', outputs('Compose_Affected_Infrastructure'), decodeUriComponent('%0A%0A'), 'Operational Context', decodeUriComponent('%0A'), 'Owning team: ', parameters('operationalContext')?['ownership']?['team'], decodeUriComponent('%0A'), 'Owning service: ', parameters('operationalContext')?['ownership']?['service'], decodeUriComponent('%0A'), 'Playbook: ', outputs('Compose_Selected_Playbook')?['name'], decodeUriComponent('%0A'), 'Playbook link: ', outputs('Compose_Selected_Playbook')?['url'], decodeUriComponent('%0A'), 'Selection: ', outputs('Compose_Selected_Playbook')?['selection'], decodeUriComponent('%0A'), if(equals(outputs('Compose_Selected_Playbook')?['url'], parameters('operationalContext')?['intakeRunbook']?['url']), '', concat('DDFun intake runbook: ', parameters('operationalContext')?['intakeRunbook']?['url'], decodeUriComponent('%0A'))), decodeUriComponent('%0A'), 'Remediation Guidance', decodeUriComponent('%0A- '), join(outputs('Compose_Selected_Playbook')?['remediationGuidance'], decodeUriComponent('%0A- ')), decodeUriComponent('%0A%0A'), 'Validation Before Resolution', decodeUriComponent('%0A- '), join(outputs('Compose_Selected_Playbook')?['validationCriteria'], decodeUriComponent('%0A- ')), decodeUriComponent('%0A%0A'), 'Filing Info', decodeUriComponent('%0A'), 'Filed by: ', outputs('Compose_Reporter'), decodeUriComponent('%0A'), 'Filing method: DncEng Teams IcM Logic App pilot', decodeUriComponent('%0A'), 'Operational context catalog: ', parameters('operationalContext')?['catalogVersion'], decodeUriComponent('%0A'), 'Teams message ID: ', outputs('Compose_Message')?['id'])"
         },
         "Create_And_Parse_IcM": {
           "type": "Scope",
@@ -554,8 +578,13 @@
                   "IcmServiceConnectorId": "@{parameters('icmConnectorId')}",
                   "Tags": [
                     "DDFun",
+                    ".NET",
+                    "DNCENG",
+                    "DNCENG-Playbook",
+                    "Teams-Automation-Created",
                     "Teams-IcM-Pilot",
-                    "AB-12383"
+                    "AB-12383",
+                    "AB-12463"
                   ]
                 },
                 "headers": {
@@ -915,6 +944,9 @@
           "Succeeded"
         ],
         "Compose_Severity": [
+          "Succeeded"
+        ],
+        "Compose_Selected_Playbook": [
           "Succeeded"
         ]
       }

--- a/eng/deployment/teams-icm-pilot.workflow.json
+++ b/eng/deployment/teams-icm-pilot.workflow.json
@@ -560,6 +560,9 @@
               "PartitionKey": "TeamsIcm",
               "RowKey": "@{outputs('Compose_Row_Key')}",
               "Status": "Created",
+              "TeamId": "@{parameters('teamId')}",
+              "ChannelId": "@{parameters('channelId')}",
+              "MessageId": "@{triggerBody()?['id']}",
               "IncidentId": "@{outputs('Compose_Incident_Id')}",
               "WorkflowRunId": "@{workflow()?['run']?['name']}",
               "UpdatedUtc": "@{utcNow()}"
@@ -571,7 +574,7 @@
               "x-ms-date": "@{utcNow('R')}",
               "x-ms-version": "2019-02-02"
             },
-            "method": "MERGE",
+            "method": "PUT",
             "uri": "@{concat(parameters('storageTableEndpoint'), parameters('storageTableName'), '(PartitionKey=''TeamsIcm'',RowKey=''', outputs('Compose_Row_Key'), ''')')}"
           },
           "runAfter": {
@@ -616,6 +619,9 @@
               "PartitionKey": "TeamsIcm",
               "RowKey": "@{outputs('Compose_Row_Key')}",
               "Status": "ReplyPosted",
+              "TeamId": "@{parameters('teamId')}",
+              "ChannelId": "@{parameters('channelId')}",
+              "MessageId": "@{triggerBody()?['id']}",
               "IncidentId": "@{outputs('Compose_Incident_Id')}",
               "WorkflowRunId": "@{workflow()?['run']?['name']}",
               "UpdatedUtc": "@{utcNow()}"
@@ -627,7 +633,7 @@
               "x-ms-date": "@{utcNow('R')}",
               "x-ms-version": "2019-02-02"
             },
-            "method": "MERGE",
+            "method": "PUT",
             "uri": "@{concat(parameters('storageTableEndpoint'), parameters('storageTableName'), '(PartitionKey=''TeamsIcm'',RowKey=''', outputs('Compose_Row_Key'), ''')')}"
           },
           "runAfter": {
@@ -647,6 +653,9 @@
               "PartitionKey": "TeamsIcm",
               "RowKey": "@{outputs('Compose_Row_Key')}",
               "Status": "Failed",
+              "TeamId": "@{parameters('teamId')}",
+              "ChannelId": "@{parameters('channelId')}",
+              "MessageId": "@{triggerBody()?['id']}",
               "FailureStage": "IcmProvider",
               "FailureStatusCode": "@{outputs('Create_Or_Update_IcM')?['statusCode']}",
               "WorkflowRunId": "@{workflow()?['run']?['name']}",
@@ -659,7 +668,7 @@
               "x-ms-date": "@{utcNow('R')}",
               "x-ms-version": "2019-02-02"
             },
-            "method": "MERGE",
+            "method": "PUT",
             "uri": "@{concat(parameters('storageTableEndpoint'), parameters('storageTableName'), '(PartitionKey=''TeamsIcm'',RowKey=''', outputs('Compose_Row_Key'), ''')')}"
           },
           "runAfter": {
@@ -724,6 +733,9 @@
               "PartitionKey": "TeamsIcm",
               "RowKey": "@{outputs('Compose_Row_Key')}",
               "Status": "Failed",
+              "TeamId": "@{parameters('teamId')}",
+              "ChannelId": "@{parameters('channelId')}",
+              "MessageId": "@{triggerBody()?['id']}",
               "FailureStage": "TeamsReply",
               "IncidentId": "@{outputs('Compose_Incident_Id')}",
               "WorkflowRunId": "@{workflow()?['run']?['name']}",
@@ -736,7 +748,7 @@
               "x-ms-date": "@{utcNow('R')}",
               "x-ms-version": "2019-02-02"
             },
-            "method": "MERGE",
+            "method": "PUT",
             "uri": "@{concat(parameters('storageTableEndpoint'), parameters('storageTableName'), '(PartitionKey=''TeamsIcm'',RowKey=''', outputs('Compose_Row_Key'), ''')')}"
           },
           "runAfter": {
@@ -777,6 +789,9 @@
                 "PartitionKey": "TeamsIcm",
                 "RowKey": "@{outputs('Compose_Row_Key')}",
                 "Status": "Failed",
+                "TeamId": "@{parameters('teamId')}",
+                "ChannelId": "@{parameters('channelId')}",
+                "MessageId": "@{triggerBody()?['id']}",
                 "FailureStage": "Validation",
                 "WorkflowRunId": "@{workflow()?['run']?['name']}",
                 "UpdatedUtc": "@{utcNow()}"
@@ -788,7 +803,7 @@
                 "x-ms-date": "@{utcNow('R')}",
                 "x-ms-version": "2019-02-02"
               },
-              "method": "MERGE",
+              "method": "PUT",
               "uri": "@{concat(parameters('storageTableEndpoint'), parameters('storageTableName'), '(PartitionKey=''TeamsIcm'',RowKey=''', outputs('Compose_Row_Key'), ''')')}"
             }
           },

--- a/eng/deployment/teams-icm-pilot.workflow.json
+++ b/eng/deployment/teams-icm-pilot.workflow.json
@@ -190,11 +190,41 @@
         ]
       }
     },
-    "Compose_Plain_Text": {
+    "Compose_Raw_Plain_Text": {
       "type": "Compose",
       "inputs": "@trim(replace(replace(replace(replace(replace(replace(replace(replace(string(triggerBody()?['body']?['content']), '<p>', ''), '</p>', decodeUriComponent('%0A')), '<br>', decodeUriComponent('%0A')), '<br/>', decodeUriComponent('%0A')), '<br />', decodeUriComponent('%0A')), '<div>', ''), '</div>', decodeUriComponent('%0A')), '&nbsp;', ' '))",
       "runAfter": {
         "Accept_New_Or_Existing_Reservation": [
+          "Succeeded"
+        ]
+      }
+    },
+    "Compose_Plain_Text": {
+      "type": "Compose",
+      "inputs": "@if(outputs('Compose_Is_Structured'), outputs('Compose_Raw_Plain_Text'), concat('Title: ', outputs('Compose_Freeform_Title'), decodeUriComponent('%0A'), 'Who/customer affected: Not specified', decodeUriComponent('%0A'), 'Impact: Free-form Teams report', decodeUriComponent('%0A'), 'Affected service/infrastructure: Not specified', decodeUriComponent('%0A'), 'Evidence or build/job URL: ', if(empty(trim(string(triggerBody()?['webUrl']))), concat('https://teams.microsoft.com/l/message/', encodeUriComponent(parameters('channelId')), '/', triggerBody()?['id'], '?groupId=', parameters('teamId'), '&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&createdTime=', triggerBody()?['id'], '&parentMessageId=', triggerBody()?['id']), trim(string(triggerBody()?['webUrl']))), decodeUriComponent('%0A'), 'Requested action: Investigate the reported issue', decodeUriComponent('%0A'), 'Reporter: ', if(empty(trim(string(triggerBody()?['from']?['user']?['displayName']))), if(empty(trim(string(triggerBody()?['from']?['application']?['displayName']))), 'Teams user', trim(string(triggerBody()?['from']?['application']?['displayName']))), trim(string(triggerBody()?['from']?['user']?['displayName']))), decodeUriComponent('%0A'), 'Severity: ', if(or(contains(toLower(outputs('Compose_Raw_Plain_Text')), 'sev3'), contains(replace(replace(toLower(outputs('Compose_Raw_Plain_Text')), ':', ' '), '-', ' '), 'sev 3'), contains(replace(replace(toLower(outputs('Compose_Raw_Plain_Text')), ':', ' '), '-', ' '), 'severity 3')), '3', '4')))",
+      "runAfter": {
+        "Compose_Is_Structured": [
+          "Succeeded"
+        ],
+        "Compose_Freeform_Title": [
+          "Succeeded"
+        ]
+      }
+    },
+    "Compose_Is_Structured": {
+      "type": "Compose",
+      "inputs": "@and(contains(outputs('Compose_Raw_Plain_Text'), 'Title:'), contains(outputs('Compose_Raw_Plain_Text'), 'Who/customer affected:'), contains(outputs('Compose_Raw_Plain_Text'), 'Impact:'), contains(outputs('Compose_Raw_Plain_Text'), 'Affected service/infrastructure:'), contains(outputs('Compose_Raw_Plain_Text'), 'Evidence or build/job URL:'), contains(outputs('Compose_Raw_Plain_Text'), 'Requested action:'), contains(outputs('Compose_Raw_Plain_Text'), 'Reporter:'), contains(outputs('Compose_Raw_Plain_Text'), 'Severity:'))",
+      "runAfter": {
+        "Compose_Raw_Plain_Text": [
+          "Succeeded"
+        ]
+      }
+    },
+    "Compose_Freeform_Title": {
+      "type": "Compose",
+      "inputs": "@take(if(empty(trim(string(triggerBody()?['subject']))), trim(first(split(outputs('Compose_Raw_Plain_Text'), decodeUriComponent('%0A')))), trim(string(triggerBody()?['subject']))), 200)",
+      "runAfter": {
+        "Compose_Raw_Plain_Text": [
           "Succeeded"
         ]
       }
@@ -219,7 +249,7 @@
     },
     "Compose_Impact": {
       "type": "Compose",
-      "inputs": "@trim(first(split(last(split(outputs('Compose_Plain_Text'), 'Impact:')), decodeUriComponent('%0A'))))",
+      "inputs": "@if(outputs('Compose_Is_Structured'), trim(first(split(last(split(outputs('Compose_Plain_Text'), 'Impact:')), decodeUriComponent('%0A')))), outputs('Compose_Raw_Plain_Text'))",
       "runAfter": {
         "Compose_Plain_Text": [
           "Succeeded"
@@ -490,7 +520,7 @@
       "actions": {
         "Compose_IcM_Description": {
           "type": "Compose",
-          "inputs": "@concat('Created from a structured root message in the .NET Eng Services Teams IcM intake channel.', decodeUriComponent('%0A%0A'), 'Impact: ', outputs('Compose_Impact'), decodeUriComponent('%0A'), 'Affected service/infrastructure: ', outputs('Compose_Affected_Infrastructure'), decodeUriComponent('%0A'), 'Evidence: ', outputs('Compose_Evidence'), decodeUriComponent('%0A'), 'Requested action: ', outputs('Compose_Requested_Action'), decodeUriComponent('%0A%0A'), '---', decodeUriComponent('%0A'), 'Incident Details (4W)', decodeUriComponent('%0A'), 'Who: ', outputs('Compose_Who'), decodeUriComponent('%0A'), 'What: ', outputs('Compose_Impact'), decodeUriComponent('%0A'), 'When: Teams message posted at ', triggerBody()?['createdDateTime'], decodeUriComponent('%0A'), 'Where: ', outputs('Compose_Affected_Infrastructure'), decodeUriComponent('%0A%0A'), 'Filing Info', decodeUriComponent('%0A'), 'Filed by: ', outputs('Compose_Reporter'), decodeUriComponent('%0A'), 'Filing method: DncEng Teams IcM Logic App pilot', decodeUriComponent('%0A'), 'Teams message ID: ', triggerBody()?['id'])"
+          "inputs": "@concat('Created from a ', if(outputs('Compose_Is_Structured'), 'structured', 'free-form'), ' root message in the .NET Eng Services Teams IcM intake channel.', decodeUriComponent('%0A%0A'), if(outputs('Compose_Is_Structured'), '', concat('Original Teams message:', decodeUriComponent('%0A'), outputs('Compose_Raw_Plain_Text'), decodeUriComponent('%0A%0A'))), 'Impact: ', outputs('Compose_Impact'), decodeUriComponent('%0A'), 'Affected service/infrastructure: ', outputs('Compose_Affected_Infrastructure'), decodeUriComponent('%0A'), 'Evidence: ', outputs('Compose_Evidence'), decodeUriComponent('%0A'), 'Requested action: ', outputs('Compose_Requested_Action'), decodeUriComponent('%0A%0A'), '---', decodeUriComponent('%0A'), 'Incident Details (4W)', decodeUriComponent('%0A'), 'Who: ', outputs('Compose_Who'), decodeUriComponent('%0A'), 'What: ', outputs('Compose_Impact'), decodeUriComponent('%0A'), 'When: Teams message posted at ', triggerBody()?['createdDateTime'], decodeUriComponent('%0A'), 'Where: ', outputs('Compose_Affected_Infrastructure'), decodeUriComponent('%0A%0A'), 'Filing Info', decodeUriComponent('%0A'), 'Filed by: ', outputs('Compose_Reporter'), decodeUriComponent('%0A'), 'Filing method: DncEng Teams IcM Logic App pilot', decodeUriComponent('%0A'), 'Teams message ID: ', triggerBody()?['id'])"
         },
         "Create_And_Parse_IcM": {
           "type": "Scope",
@@ -505,7 +535,7 @@
                 "body": {
                   "Title": "@{outputs('Compose_Title')}",
                   "Description": "@{outputs('Compose_IcM_Description')}",
-                  "Summary": "@{outputs('Compose_Impact')}",
+                  "Summary": "@{take(outputs('Compose_Impact'), 500)}",
                   "TeamRoutingRuleId": "@{parameters('icmRoutingRuleId')}",
                   "Severity": "@{int(outputs('Compose_Severity'))}",
                   "Status": 1,
@@ -811,7 +841,7 @@
             "type": "ApiConnection",
             "inputs": {
               "body": {
-                "messageBody": "<p>No IcM was created because the request is incomplete or uses an unsupported severity. Submit a new root message with non-empty values using this exact template:</p><pre>Title:\nWho/customer affected:\nImpact:\nAffected service/infrastructure:\nEvidence or build/job URL:\nRequested action:\nReporter:\nSeverity: 3 or 4</pre>",
+                "messageBody": "<p>No IcM was created because the root message did not contain enough information. Submit a new root message with a subject and description. You can optionally override the inferred values with this exact template:</p><pre>Title:\nWho/customer affected:\nImpact:\nAffected service/infrastructure:\nEvidence or build/job URL:\nRequested action:\nReporter:\nSeverity: 3 or 4</pre>",
                 "parentMessageId": "@{triggerBody()?['id']}",
                 "recipient": {
                   "groupId": "@{parameters('teamId')}",

--- a/eng/deployment/teams-icm-pilot.workflow.json
+++ b/eng/deployment/teams-icm-pilot.workflow.json
@@ -32,22 +32,22 @@
     }
   },
   "triggers": {
-    "When_a_new_channel_message_is_added": {
-      "type": "ApiConnection",
+    "Process_Teams_Message": {
+      "type": "Request",
+      "kind": "Http",
       "inputs": {
-        "host": {
-          "connection": {
-            "name": "@parameters('$connections')['teams']['connectionId']"
+        "schema": {
+          "type": "object",
+          "required": [
+            "message"
+          ],
+          "properties": {
+            "message": {
+              "type": "object"
+            }
           }
-        },
-        "method": "get",
-        "path": "/trigger/beta/teams/@{encodeURIComponent(parameters('teamId'))}/channels/@{encodeURIComponent(parameters('channelId'))}/messages"
+        }
       },
-      "recurrence": {
-        "frequency": "Minute",
-        "interval": 3
-      },
-      "splitOn": "@triggerBody()",
       "runtimeConfiguration": {
         "concurrency": {
           "runs": 1
@@ -56,10 +56,19 @@
     }
   },
   "actions": {
+    "Compose_Message": {
+      "type": "Compose",
+      "inputs": "@triggerBody()?['message']",
+      "runAfter": {}
+    },
     "Compose_Row_Key": {
       "type": "Compose",
-      "inputs": "@replace(replace(replace(replace(string(triggerBody()?['id']), '/', '_'), '\\', '_'), '#', '_'), '?', '_')",
-      "runAfter": {}
+      "inputs": "@replace(replace(replace(replace(string(outputs('Compose_Message')?['id']), '/', '_'), '\\', '_'), '#', '_'), '?', '_')",
+      "runAfter": {
+        "Compose_Message": [
+          "Succeeded"
+        ]
+      }
     },
     "Reserve_Message": {
       "type": "Http",
@@ -74,7 +83,7 @@
           "Status": "Processing",
           "TeamId": "@{parameters('teamId')}",
           "ChannelId": "@{parameters('channelId')}",
-          "MessageId": "@{triggerBody()?['id']}",
+          "MessageId": "@{outputs('Compose_Message')?['id']}",
           "WorkflowRunId": "@{workflow()?['run']?['name']}",
           "UpdatedUtc": "@{utcNow()}"
         },
@@ -192,7 +201,7 @@
     },
     "Compose_Raw_Plain_Text": {
       "type": "Compose",
-      "inputs": "@trim(replace(replace(replace(replace(replace(replace(replace(replace(string(triggerBody()?['body']?['content']), '<p>', ''), '</p>', decodeUriComponent('%0A')), '<br>', decodeUriComponent('%0A')), '<br/>', decodeUriComponent('%0A')), '<br />', decodeUriComponent('%0A')), '<div>', ''), '</div>', decodeUriComponent('%0A')), '&nbsp;', ' '))",
+      "inputs": "@trim(replace(replace(replace(replace(replace(replace(replace(replace(string(outputs('Compose_Message')?['body']?['content']), '<p>', ''), '</p>', decodeUriComponent('%0A')), '<br>', decodeUriComponent('%0A')), '<br/>', decodeUriComponent('%0A')), '<br />', decodeUriComponent('%0A')), '<div>', ''), '</div>', decodeUriComponent('%0A')), '&nbsp;', ' '))",
       "runAfter": {
         "Accept_New_Or_Existing_Reservation": [
           "Succeeded"
@@ -201,7 +210,7 @@
     },
     "Compose_Plain_Text": {
       "type": "Compose",
-      "inputs": "@if(outputs('Compose_Is_Structured'), outputs('Compose_Raw_Plain_Text'), concat('Title: ', outputs('Compose_Freeform_Title'), decodeUriComponent('%0A'), 'Who/customer affected: Not specified', decodeUriComponent('%0A'), 'Impact: Free-form Teams report', decodeUriComponent('%0A'), 'Affected service/infrastructure: Not specified', decodeUriComponent('%0A'), 'Evidence or build/job URL: ', if(empty(trim(string(triggerBody()?['webUrl']))), concat('https://teams.microsoft.com/l/message/', encodeUriComponent(parameters('channelId')), '/', triggerBody()?['id'], '?groupId=', parameters('teamId'), '&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&createdTime=', triggerBody()?['id'], '&parentMessageId=', triggerBody()?['id']), trim(string(triggerBody()?['webUrl']))), decodeUriComponent('%0A'), 'Requested action: Investigate the reported issue', decodeUriComponent('%0A'), 'Reporter: ', if(empty(trim(string(triggerBody()?['from']?['user']?['displayName']))), if(empty(trim(string(triggerBody()?['from']?['application']?['displayName']))), 'Teams user', trim(string(triggerBody()?['from']?['application']?['displayName']))), trim(string(triggerBody()?['from']?['user']?['displayName']))), decodeUriComponent('%0A'), 'Severity: ', if(or(contains(toLower(outputs('Compose_Raw_Plain_Text')), 'sev3'), contains(replace(replace(toLower(outputs('Compose_Raw_Plain_Text')), ':', ' '), '-', ' '), 'sev 3'), contains(replace(replace(toLower(outputs('Compose_Raw_Plain_Text')), ':', ' '), '-', ' '), 'severity 3')), '3', '4')))",
+      "inputs": "@if(outputs('Compose_Is_Structured'), outputs('Compose_Raw_Plain_Text'), concat('Title: ', outputs('Compose_Freeform_Title'), decodeUriComponent('%0A'), 'Who/customer affected: Not specified', decodeUriComponent('%0A'), 'Impact: Free-form Teams report', decodeUriComponent('%0A'), 'Affected service/infrastructure: Not specified', decodeUriComponent('%0A'), 'Evidence or build/job URL: ', if(empty(trim(string(outputs('Compose_Message')?['webUrl']))), concat('https://teams.microsoft.com/l/message/', encodeUriComponent(parameters('channelId')), '/', outputs('Compose_Message')?['id'], '?groupId=', parameters('teamId'), '&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&createdTime=', outputs('Compose_Message')?['id'], '&parentMessageId=', outputs('Compose_Message')?['id']), trim(string(outputs('Compose_Message')?['webUrl']))), decodeUriComponent('%0A'), 'Requested action: Investigate the reported issue', decodeUriComponent('%0A'), 'Reporter: ', if(empty(trim(string(outputs('Compose_Message')?['from']?['user']?['displayName']))), if(empty(trim(string(outputs('Compose_Message')?['from']?['application']?['displayName']))), 'Teams user', trim(string(outputs('Compose_Message')?['from']?['application']?['displayName']))), trim(string(outputs('Compose_Message')?['from']?['user']?['displayName']))), decodeUriComponent('%0A'), 'Severity: ', if(or(contains(toLower(outputs('Compose_Raw_Plain_Text')), 'sev3'), contains(replace(replace(toLower(outputs('Compose_Raw_Plain_Text')), ':', ' '), '-', ' '), 'sev 3'), contains(replace(replace(toLower(outputs('Compose_Raw_Plain_Text')), ':', ' '), '-', ' '), 'severity 3')), '3', '4')))",
       "runAfter": {
         "Compose_Is_Structured": [
           "Succeeded"
@@ -222,7 +231,7 @@
     },
     "Compose_Freeform_Title": {
       "type": "Compose",
-      "inputs": "@take(if(empty(trim(string(triggerBody()?['subject']))), trim(first(split(outputs('Compose_Raw_Plain_Text'), decodeUriComponent('%0A')))), trim(string(triggerBody()?['subject']))), 200)",
+      "inputs": "@take(if(empty(trim(string(outputs('Compose_Message')?['subject']))), trim(first(split(outputs('Compose_Raw_Plain_Text'), decodeUriComponent('%0A')))), trim(string(outputs('Compose_Message')?['subject']))), 200)",
       "runAfter": {
         "Compose_Raw_Plain_Text": [
           "Succeeded"
@@ -520,7 +529,7 @@
       "actions": {
         "Compose_IcM_Description": {
           "type": "Compose",
-          "inputs": "@concat('Created from a ', if(outputs('Compose_Is_Structured'), 'structured', 'free-form'), ' root message in the .NET Eng Services Teams IcM intake channel.', decodeUriComponent('%0A%0A'), if(outputs('Compose_Is_Structured'), '', concat('Original Teams message:', decodeUriComponent('%0A'), outputs('Compose_Raw_Plain_Text'), decodeUriComponent('%0A%0A'))), 'Impact: ', outputs('Compose_Impact'), decodeUriComponent('%0A'), 'Affected service/infrastructure: ', outputs('Compose_Affected_Infrastructure'), decodeUriComponent('%0A'), 'Evidence: ', outputs('Compose_Evidence'), decodeUriComponent('%0A'), 'Requested action: ', outputs('Compose_Requested_Action'), decodeUriComponent('%0A%0A'), '---', decodeUriComponent('%0A'), 'Incident Details (4W)', decodeUriComponent('%0A'), 'Who: ', outputs('Compose_Who'), decodeUriComponent('%0A'), 'What: ', outputs('Compose_Impact'), decodeUriComponent('%0A'), 'When: Teams message posted at ', triggerBody()?['createdDateTime'], decodeUriComponent('%0A'), 'Where: ', outputs('Compose_Affected_Infrastructure'), decodeUriComponent('%0A%0A'), 'Filing Info', decodeUriComponent('%0A'), 'Filed by: ', outputs('Compose_Reporter'), decodeUriComponent('%0A'), 'Filing method: DncEng Teams IcM Logic App pilot', decodeUriComponent('%0A'), 'Teams message ID: ', triggerBody()?['id'])"
+          "inputs": "@concat('Created from a ', if(outputs('Compose_Is_Structured'), 'structured', 'free-form'), ' root message in the .NET Eng Services Teams IcM intake channel.', decodeUriComponent('%0A%0A'), if(outputs('Compose_Is_Structured'), '', concat('Original Teams message:', decodeUriComponent('%0A'), outputs('Compose_Raw_Plain_Text'), decodeUriComponent('%0A%0A'))), 'Impact: ', outputs('Compose_Impact'), decodeUriComponent('%0A'), 'Affected service/infrastructure: ', outputs('Compose_Affected_Infrastructure'), decodeUriComponent('%0A'), 'Evidence: ', outputs('Compose_Evidence'), decodeUriComponent('%0A'), 'Requested action: ', outputs('Compose_Requested_Action'), decodeUriComponent('%0A%0A'), '---', decodeUriComponent('%0A'), 'Incident Details (4W)', decodeUriComponent('%0A'), 'Who: ', outputs('Compose_Who'), decodeUriComponent('%0A'), 'What: ', outputs('Compose_Impact'), decodeUriComponent('%0A'), 'When: Teams message posted at ', outputs('Compose_Message')?['createdDateTime'], decodeUriComponent('%0A'), 'Where: ', outputs('Compose_Affected_Infrastructure'), decodeUriComponent('%0A%0A'), 'Filing Info', decodeUriComponent('%0A'), 'Filed by: ', outputs('Compose_Reporter'), decodeUriComponent('%0A'), 'Filing method: DncEng Teams IcM Logic App pilot', decodeUriComponent('%0A'), 'Teams message ID: ', outputs('Compose_Message')?['id'])"
         },
         "Create_And_Parse_IcM": {
           "type": "Scope",
@@ -592,7 +601,7 @@
               "Status": "Created",
               "TeamId": "@{parameters('teamId')}",
               "ChannelId": "@{parameters('channelId')}",
-              "MessageId": "@{triggerBody()?['id']}",
+              "MessageId": "@{outputs('Compose_Message')?['id']}",
               "IncidentId": "@{outputs('Compose_Incident_Id')}",
               "WorkflowRunId": "@{workflow()?['run']?['name']}",
               "UpdatedUtc": "@{utcNow()}"
@@ -618,7 +627,7 @@
           "inputs": {
             "body": {
               "messageBody": "<p>Created <a href=\"https://portal.microsofticm.com/imp/v5/incidents/details/@{outputs('Compose_Incident_Id')}/summary\">IcM @{outputs('Compose_Incident_Id')}</a> and routed it to DDFun Customer Requests.</p>",
-              "parentMessageId": "@{triggerBody()?['id']}",
+              "parentMessageId": "@{outputs('Compose_Message')?['id']}",
               "recipient": {
                 "groupId": "@{parameters('teamId')}",
                 "channelId": "@{parameters('channelId')}"
@@ -651,7 +660,7 @@
               "Status": "ReplyPosted",
               "TeamId": "@{parameters('teamId')}",
               "ChannelId": "@{parameters('channelId')}",
-              "MessageId": "@{triggerBody()?['id']}",
+              "MessageId": "@{outputs('Compose_Message')?['id']}",
               "IncidentId": "@{outputs('Compose_Incident_Id')}",
               "WorkflowRunId": "@{workflow()?['run']?['name']}",
               "UpdatedUtc": "@{utcNow()}"
@@ -685,7 +694,7 @@
               "Status": "Failed",
               "TeamId": "@{parameters('teamId')}",
               "ChannelId": "@{parameters('channelId')}",
-              "MessageId": "@{triggerBody()?['id']}",
+              "MessageId": "@{outputs('Compose_Message')?['id']}",
               "FailureStage": "IcmProvider",
               "FailureStatusCode": "@{outputs('Create_Or_Update_IcM')?['statusCode']}",
               "WorkflowRunId": "@{workflow()?['run']?['name']}",
@@ -713,7 +722,7 @@
           "inputs": {
             "body": {
               "messageBody": "<p>The IcM request failed. No successful incident creation was recorded. Please contact the .NET Engineering Services First Responder and include workflow run <code>@{workflow()?['run']?['name']}</code>.</p>",
-              "parentMessageId": "@{triggerBody()?['id']}",
+              "parentMessageId": "@{outputs('Compose_Message')?['id']}",
               "recipient": {
                 "groupId": "@{parameters('teamId')}",
                 "channelId": "@{parameters('channelId')}"
@@ -765,7 +774,7 @@
               "Status": "Failed",
               "TeamId": "@{parameters('teamId')}",
               "ChannelId": "@{parameters('channelId')}",
-              "MessageId": "@{triggerBody()?['id']}",
+              "MessageId": "@{outputs('Compose_Message')?['id']}",
               "FailureStage": "TeamsReply",
               "IncidentId": "@{outputs('Compose_Incident_Id')}",
               "WorkflowRunId": "@{workflow()?['run']?['name']}",
@@ -821,7 +830,7 @@
                 "Status": "Failed",
                 "TeamId": "@{parameters('teamId')}",
                 "ChannelId": "@{parameters('channelId')}",
-                "MessageId": "@{triggerBody()?['id']}",
+                "MessageId": "@{outputs('Compose_Message')?['id']}",
                 "FailureStage": "Validation",
                 "WorkflowRunId": "@{workflow()?['run']?['name']}",
                 "UpdatedUtc": "@{utcNow()}"
@@ -842,7 +851,7 @@
             "inputs": {
               "body": {
                 "messageBody": "<p>No IcM was created because the root message did not contain enough information. Submit a new root message with a subject and description. You can optionally override the inferred values with this exact template:</p><pre>Title:\nWho/customer affected:\nImpact:\nAffected service/infrastructure:\nEvidence or build/job URL:\nRequested action:\nReporter:\nSeverity: 3 or 4</pre>",
-                "parentMessageId": "@{triggerBody()?['id']}",
+                "parentMessageId": "@{outputs('Compose_Message')?['id']}",
                 "recipient": {
                   "groupId": "@{parameters('teamId')}",
                   "channelId": "@{parameters('channelId')}"

--- a/eng/deployment/teams-icm-pilot.workflow.json
+++ b/eng/deployment/teams-icm-pilot.workflow.json
@@ -1,0 +1,870 @@
+{
+  "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "$connections": {
+      "defaultValue": {},
+      "type": "Object"
+    },
+    "storageTableEndpoint": {
+      "type": "String"
+    },
+    "storageTableName": {
+      "type": "String"
+    },
+    "teamId": {
+      "type": "String"
+    },
+    "channelId": {
+      "type": "String"
+    },
+    "icmProviderEndpoint": {
+      "type": "String"
+    },
+    "icmProviderAudience": {
+      "type": "String"
+    },
+    "icmConnectorId": {
+      "type": "String"
+    },
+    "icmRoutingRuleId": {
+      "type": "String"
+    }
+  },
+  "triggers": {
+    "When_a_new_channel_message_is_added": {
+      "type": "ApiConnection",
+      "inputs": {
+        "host": {
+          "connection": {
+            "name": "@parameters('$connections')['teams']['connectionId']"
+          }
+        },
+        "method": "get",
+        "path": "/trigger/beta/teams/@{encodeURIComponent(parameters('teamId'))}/channels/@{encodeURIComponent(parameters('channelId'))}/messages"
+      },
+      "recurrence": {
+        "frequency": "Minute",
+        "interval": 3
+      },
+      "splitOn": "@triggerBody()",
+      "runtimeConfiguration": {
+        "concurrency": {
+          "runs": 1
+        }
+      }
+    }
+  },
+  "actions": {
+    "Compose_Row_Key": {
+      "type": "Compose",
+      "inputs": "@replace(replace(replace(replace(string(triggerBody()?['id']), '/', '_'), '\\', '_'), '#', '_'), '?', '_')",
+      "runAfter": {}
+    },
+    "Reserve_Message": {
+      "type": "Http",
+      "inputs": {
+        "authentication": {
+          "type": "ManagedServiceIdentity",
+          "audience": "https://storage.azure.com/"
+        },
+        "body": {
+          "PartitionKey": "TeamsIcm",
+          "RowKey": "@{outputs('Compose_Row_Key')}",
+          "Status": "Processing",
+          "TeamId": "@{parameters('teamId')}",
+          "ChannelId": "@{parameters('channelId')}",
+          "MessageId": "@{triggerBody()?['id']}",
+          "WorkflowRunId": "@{workflow()?['run']?['name']}",
+          "UpdatedUtc": "@{utcNow()}"
+        },
+        "headers": {
+          "Accept": "application/json;odata=nometadata",
+          "Content-Type": "application/json",
+          "x-ms-date": "@{utcNow('R')}",
+          "x-ms-version": "2019-02-02"
+        },
+        "method": "POST",
+        "uri": "@{concat(parameters('storageTableEndpoint'), parameters('storageTableName'))}"
+      },
+      "runAfter": {
+        "Compose_Row_Key": [
+          "Succeeded"
+        ]
+      }
+    },
+    "Accept_New_Or_Existing_Reservation": {
+      "type": "If",
+      "expression": {
+        "or": [
+          {
+            "equals": [
+              "@outputs('Reserve_Message')?['statusCode']",
+              201
+            ]
+          },
+          {
+            "equals": [
+              "@outputs('Reserve_Message')?['statusCode']",
+              204
+            ]
+          }
+        ]
+      },
+      "actions": {},
+      "else": {
+        "actions": {
+          "Is_Duplicate_Delivery": {
+            "type": "If",
+            "expression": {
+              "equals": [
+                "@outputs('Reserve_Message')?['statusCode']",
+                409
+              ]
+            },
+            "actions": {
+              "Get_Existing_State": {
+                "type": "Http",
+                "inputs": {
+                  "authentication": {
+                    "type": "ManagedServiceIdentity",
+                    "audience": "https://storage.azure.com/"
+                  },
+                  "headers": {
+                    "Accept": "application/json;odata=nometadata",
+                    "x-ms-date": "@{utcNow('R')}",
+                    "x-ms-version": "2019-02-02"
+                  },
+                  "method": "GET",
+                  "uri": "@{concat(parameters('storageTableEndpoint'), parameters('storageTableName'), '(PartitionKey=''TeamsIcm'',RowKey=''', outputs('Compose_Row_Key'), ''')')}"
+                }
+              },
+              "Already_Replied": {
+                "type": "If",
+                "expression": {
+                  "equals": [
+                    "@body('Get_Existing_State')?['Status']",
+                    "ReplyPosted"
+                  ]
+                },
+                "actions": {
+                  "Stop_Duplicate": {
+                    "type": "Terminate",
+                    "inputs": {
+                      "runStatus": "Succeeded"
+                    }
+                  }
+                },
+                "else": {
+                  "actions": {}
+                },
+                "runAfter": {
+                  "Get_Existing_State": [
+                    "Succeeded"
+                  ]
+                }
+              }
+            },
+            "else": {
+              "actions": {
+                "Stop_Reservation_Failure": {
+                  "type": "Terminate",
+                  "inputs": {
+                    "runStatus": "Failed",
+                    "runError": {
+                      "code": "StorageReservationFailed",
+                      "message": "The intake message could not be reserved in Azure Table Storage."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "runAfter": {
+        "Reserve_Message": [
+          "Succeeded",
+          "Failed",
+          "TimedOut"
+        ]
+      }
+    },
+    "Compose_Plain_Text": {
+      "type": "Compose",
+      "inputs": "@trim(replace(replace(replace(replace(replace(replace(replace(replace(string(triggerBody()?['body']?['content']), '<p>', ''), '</p>', decodeUriComponent('%0A')), '<br>', decodeUriComponent('%0A')), '<br/>', decodeUriComponent('%0A')), '<br />', decodeUriComponent('%0A')), '<div>', ''), '</div>', decodeUriComponent('%0A')), '&nbsp;', ' '))",
+      "runAfter": {
+        "Accept_New_Or_Existing_Reservation": [
+          "Succeeded"
+        ]
+      }
+    },
+    "Compose_Title": {
+      "type": "Compose",
+      "inputs": "@trim(first(split(last(split(outputs('Compose_Plain_Text'), 'Title:')), decodeUriComponent('%0A'))))",
+      "runAfter": {
+        "Compose_Plain_Text": [
+          "Succeeded"
+        ]
+      }
+    },
+    "Compose_Who": {
+      "type": "Compose",
+      "inputs": "@trim(first(split(last(split(outputs('Compose_Plain_Text'), 'Who/customer affected:')), decodeUriComponent('%0A'))))",
+      "runAfter": {
+        "Compose_Plain_Text": [
+          "Succeeded"
+        ]
+      }
+    },
+    "Compose_Impact": {
+      "type": "Compose",
+      "inputs": "@trim(first(split(last(split(outputs('Compose_Plain_Text'), 'Impact:')), decodeUriComponent('%0A'))))",
+      "runAfter": {
+        "Compose_Plain_Text": [
+          "Succeeded"
+        ]
+      }
+    },
+    "Compose_Affected_Infrastructure": {
+      "type": "Compose",
+      "inputs": "@trim(first(split(last(split(outputs('Compose_Plain_Text'), 'Affected service/infrastructure:')), decodeUriComponent('%0A'))))",
+      "runAfter": {
+        "Compose_Plain_Text": [
+          "Succeeded"
+        ]
+      }
+    },
+    "Compose_Evidence": {
+      "type": "Compose",
+      "inputs": "@trim(first(split(last(split(outputs('Compose_Plain_Text'), 'Evidence or build/job URL:')), decodeUriComponent('%0A'))))",
+      "runAfter": {
+        "Compose_Plain_Text": [
+          "Succeeded"
+        ]
+      }
+    },
+    "Compose_Requested_Action": {
+      "type": "Compose",
+      "inputs": "@trim(first(split(last(split(outputs('Compose_Plain_Text'), 'Requested action:')), decodeUriComponent('%0A'))))",
+      "runAfter": {
+        "Compose_Plain_Text": [
+          "Succeeded"
+        ]
+      }
+    },
+    "Compose_Reporter": {
+      "type": "Compose",
+      "inputs": "@trim(first(split(last(split(outputs('Compose_Plain_Text'), 'Reporter:')), decodeUriComponent('%0A'))))",
+      "runAfter": {
+        "Compose_Plain_Text": [
+          "Succeeded"
+        ]
+      }
+    },
+    "Compose_Severity": {
+      "type": "Compose",
+      "inputs": "@trim(first(split(last(split(outputs('Compose_Plain_Text'), 'Severity:')), decodeUriComponent('%0A'))))",
+      "runAfter": {
+        "Compose_Plain_Text": [
+          "Succeeded"
+        ]
+      }
+    },
+    "Validate_Intake": {
+      "type": "If",
+      "expression": {
+        "and": [
+          {
+            "contains": [
+              "@outputs('Compose_Plain_Text')",
+              "Title:"
+            ]
+          },
+          {
+            "contains": [
+              "@outputs('Compose_Plain_Text')",
+              "Who/customer affected:"
+            ]
+          },
+          {
+            "contains": [
+              "@outputs('Compose_Plain_Text')",
+              "Impact:"
+            ]
+          },
+          {
+            "contains": [
+              "@outputs('Compose_Plain_Text')",
+              "Affected service/infrastructure:"
+            ]
+          },
+          {
+            "contains": [
+              "@outputs('Compose_Plain_Text')",
+              "Evidence or build/job URL:"
+            ]
+          },
+          {
+            "contains": [
+              "@outputs('Compose_Plain_Text')",
+              "Requested action:"
+            ]
+          },
+          {
+            "contains": [
+              "@outputs('Compose_Plain_Text')",
+              "Reporter:"
+            ]
+          },
+          {
+            "contains": [
+              "@outputs('Compose_Plain_Text')",
+              "Severity:"
+            ]
+          },
+          {
+            "equals": [
+              "@length(split(outputs('Compose_Plain_Text'), 'Title:'))",
+              2
+            ]
+          },
+          {
+            "equals": [
+              "@length(split(outputs('Compose_Plain_Text'), 'Who/customer affected:'))",
+              2
+            ]
+          },
+          {
+            "equals": [
+              "@length(split(outputs('Compose_Plain_Text'), 'Impact:'))",
+              2
+            ]
+          },
+          {
+            "equals": [
+              "@length(split(outputs('Compose_Plain_Text'), 'Affected service/infrastructure:'))",
+              2
+            ]
+          },
+          {
+            "equals": [
+              "@length(split(outputs('Compose_Plain_Text'), 'Evidence or build/job URL:'))",
+              2
+            ]
+          },
+          {
+            "equals": [
+              "@length(split(outputs('Compose_Plain_Text'), 'Requested action:'))",
+              2
+            ]
+          },
+          {
+            "equals": [
+              "@length(split(outputs('Compose_Plain_Text'), 'Reporter:'))",
+              2
+            ]
+          },
+          {
+            "equals": [
+              "@length(split(outputs('Compose_Plain_Text'), 'Severity:'))",
+              2
+            ]
+          },
+          {
+            "less": [
+              "@indexOf(outputs('Compose_Plain_Text'), 'Title:')",
+              "@indexOf(outputs('Compose_Plain_Text'), 'Who/customer affected:')"
+            ]
+          },
+          {
+            "less": [
+              "@indexOf(outputs('Compose_Plain_Text'), 'Who/customer affected:')",
+              "@indexOf(outputs('Compose_Plain_Text'), 'Impact:')"
+            ]
+          },
+          {
+            "less": [
+              "@indexOf(outputs('Compose_Plain_Text'), 'Impact:')",
+              "@indexOf(outputs('Compose_Plain_Text'), 'Affected service/infrastructure:')"
+            ]
+          },
+          {
+            "less": [
+              "@indexOf(outputs('Compose_Plain_Text'), 'Affected service/infrastructure:')",
+              "@indexOf(outputs('Compose_Plain_Text'), 'Evidence or build/job URL:')"
+            ]
+          },
+          {
+            "less": [
+              "@indexOf(outputs('Compose_Plain_Text'), 'Evidence or build/job URL:')",
+              "@indexOf(outputs('Compose_Plain_Text'), 'Requested action:')"
+            ]
+          },
+          {
+            "less": [
+              "@indexOf(outputs('Compose_Plain_Text'), 'Requested action:')",
+              "@indexOf(outputs('Compose_Plain_Text'), 'Reporter:')"
+            ]
+          },
+          {
+            "less": [
+              "@indexOf(outputs('Compose_Plain_Text'), 'Reporter:')",
+              "@indexOf(outputs('Compose_Plain_Text'), 'Severity:')"
+            ]
+          },
+          {
+            "not": {
+              "equals": [
+                "@outputs('Compose_Title')",
+                ""
+              ]
+            }
+          },
+          {
+            "not": {
+              "equals": [
+                "@outputs('Compose_Who')",
+                ""
+              ]
+            }
+          },
+          {
+            "not": {
+              "equals": [
+                "@outputs('Compose_Impact')",
+                ""
+              ]
+            }
+          },
+          {
+            "not": {
+              "equals": [
+                "@outputs('Compose_Affected_Infrastructure')",
+                ""
+              ]
+            }
+          },
+          {
+            "not": {
+              "equals": [
+                "@outputs('Compose_Evidence')",
+                ""
+              ]
+            }
+          },
+          {
+            "not": {
+              "equals": [
+                "@outputs('Compose_Requested_Action')",
+                ""
+              ]
+            }
+          },
+          {
+            "not": {
+              "equals": [
+                "@outputs('Compose_Reporter')",
+                ""
+              ]
+            }
+          },
+          {
+            "or": [
+              {
+                "equals": [
+                  "@outputs('Compose_Severity')",
+                  "3"
+                ]
+              },
+              {
+                "equals": [
+                  "@outputs('Compose_Severity')",
+                  "4"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "actions": {
+        "Compose_IcM_Description": {
+          "type": "Compose",
+          "inputs": "@concat('Created from a structured root message in the .NET Eng Services Teams IcM intake channel.', decodeUriComponent('%0A%0A'), 'Impact: ', outputs('Compose_Impact'), decodeUriComponent('%0A'), 'Affected service/infrastructure: ', outputs('Compose_Affected_Infrastructure'), decodeUriComponent('%0A'), 'Evidence: ', outputs('Compose_Evidence'), decodeUriComponent('%0A'), 'Requested action: ', outputs('Compose_Requested_Action'), decodeUriComponent('%0A%0A'), '---', decodeUriComponent('%0A'), 'Incident Details (4W)', decodeUriComponent('%0A'), 'Who: ', outputs('Compose_Who'), decodeUriComponent('%0A'), 'What: ', outputs('Compose_Impact'), decodeUriComponent('%0A'), 'When: Teams message posted at ', triggerBody()?['createdDateTime'], decodeUriComponent('%0A'), 'Where: ', outputs('Compose_Affected_Infrastructure'), decodeUriComponent('%0A%0A'), 'Filing Info', decodeUriComponent('%0A'), 'Filed by: ', outputs('Compose_Reporter'), decodeUriComponent('%0A'), 'Filing method: DncEng Teams IcM Logic App pilot', decodeUriComponent('%0A'), 'Teams message ID: ', triggerBody()?['id'])"
+        },
+        "Create_And_Parse_IcM": {
+          "type": "Scope",
+          "actions": {
+            "Create_Or_Update_IcM": {
+              "type": "Http",
+              "inputs": {
+                "authentication": {
+                  "type": "ManagedServiceIdentity",
+                  "audience": "@parameters('icmProviderAudience')"
+                },
+                "body": {
+                  "Title": "@{outputs('Compose_Title')}",
+                  "Description": "@{outputs('Compose_IcM_Description')}",
+                  "Summary": "@{outputs('Compose_Impact')}",
+                  "TeamRoutingRuleId": "@{parameters('icmRoutingRuleId')}",
+                  "Severity": "@{int(outputs('Compose_Severity'))}",
+                  "Status": 1,
+                  "SourceUserName": "@{outputs('Compose_Reporter')}",
+                  "SourceOrigin": "DncEng Teams IcM Pilot",
+                  "AlertSourceIncidentId": "AB12383-@{outputs('Compose_Row_Key')}",
+                  "IcmServiceConnectorId": "@{parameters('icmConnectorId')}",
+                  "Tags": [
+                    "DDFun",
+                    "Teams-IcM-Pilot",
+                    "AB-12383"
+                  ]
+                },
+                "headers": {
+                  "Content-Type": "application/json"
+                },
+                "method": "POST",
+                "retryPolicy": {
+                  "type": "exponential",
+                  "count": 3,
+                  "interval": "PT10S",
+                  "minimumInterval": "PT10S",
+                  "maximumInterval": "PT1M"
+                },
+                "uri": "@parameters('icmProviderEndpoint')"
+              }
+            },
+            "Compose_Incident_Id": {
+              "type": "Compose",
+              "inputs": "@int(json(body('Create_Or_Update_IcM'))?['IncidentId'])",
+              "runAfter": {
+                "Create_Or_Update_IcM": [
+                  "Succeeded"
+                ]
+              }
+            }
+          },
+          "runAfter": {
+            "Compose_IcM_Description": [
+              "Succeeded"
+            ]
+          }
+        },
+        "Record_IcM_Created": {
+          "type": "Http",
+          "inputs": {
+            "authentication": {
+              "type": "ManagedServiceIdentity",
+              "audience": "https://storage.azure.com/"
+            },
+            "body": {
+              "PartitionKey": "TeamsIcm",
+              "RowKey": "@{outputs('Compose_Row_Key')}",
+              "Status": "Created",
+              "IncidentId": "@{outputs('Compose_Incident_Id')}",
+              "WorkflowRunId": "@{workflow()?['run']?['name']}",
+              "UpdatedUtc": "@{utcNow()}"
+            },
+            "headers": {
+              "Accept": "application/json;odata=nometadata",
+              "Content-Type": "application/json",
+              "If-Match": "*",
+              "x-ms-date": "@{utcNow('R')}",
+              "x-ms-version": "2019-02-02"
+            },
+            "method": "MERGE",
+            "uri": "@{concat(parameters('storageTableEndpoint'), parameters('storageTableName'), '(PartitionKey=''TeamsIcm'',RowKey=''', outputs('Compose_Row_Key'), ''')')}"
+          },
+          "runAfter": {
+            "Create_And_Parse_IcM": [
+              "Succeeded"
+            ]
+          }
+        },
+        "Reply_With_IcM_Link": {
+          "type": "ApiConnection",
+          "inputs": {
+            "body": {
+              "messageBody": "<p>Created <a href=\"https://portal.microsofticm.com/imp/v5/incidents/details/@{outputs('Compose_Incident_Id')}/summary\">IcM @{outputs('Compose_Incident_Id')}</a> and routed it to DDFun Customer Requests.</p>",
+              "parentMessageId": "@{triggerBody()?['id']}",
+              "recipient": {
+                "groupId": "@{parameters('teamId')}",
+                "channelId": "@{parameters('channelId')}"
+              }
+            },
+            "host": {
+              "connection": {
+                "name": "@parameters('$connections')['teams']['connectionId']"
+              }
+            },
+            "method": "post",
+            "path": "/v1.0/teams/conversation/replyWithMessage/poster/@{encodeURIComponent('Flow bot')}/location/@{encodeURIComponent('Channel')}"
+          },
+          "runAfter": {
+            "Record_IcM_Created": [
+              "Succeeded"
+            ]
+          }
+        },
+        "Record_Reply_Posted": {
+          "type": "Http",
+          "inputs": {
+            "authentication": {
+              "type": "ManagedServiceIdentity",
+              "audience": "https://storage.azure.com/"
+            },
+            "body": {
+              "PartitionKey": "TeamsIcm",
+              "RowKey": "@{outputs('Compose_Row_Key')}",
+              "Status": "ReplyPosted",
+              "IncidentId": "@{outputs('Compose_Incident_Id')}",
+              "WorkflowRunId": "@{workflow()?['run']?['name']}",
+              "UpdatedUtc": "@{utcNow()}"
+            },
+            "headers": {
+              "Accept": "application/json;odata=nometadata",
+              "Content-Type": "application/json",
+              "If-Match": "*",
+              "x-ms-date": "@{utcNow('R')}",
+              "x-ms-version": "2019-02-02"
+            },
+            "method": "MERGE",
+            "uri": "@{concat(parameters('storageTableEndpoint'), parameters('storageTableName'), '(PartitionKey=''TeamsIcm'',RowKey=''', outputs('Compose_Row_Key'), ''')')}"
+          },
+          "runAfter": {
+            "Reply_With_IcM_Link": [
+              "Succeeded"
+            ]
+          }
+        },
+        "Record_Provider_Failure": {
+          "type": "Http",
+          "inputs": {
+            "authentication": {
+              "type": "ManagedServiceIdentity",
+              "audience": "https://storage.azure.com/"
+            },
+            "body": {
+              "PartitionKey": "TeamsIcm",
+              "RowKey": "@{outputs('Compose_Row_Key')}",
+              "Status": "Failed",
+              "FailureStage": "IcmProvider",
+              "FailureStatusCode": "@{outputs('Create_Or_Update_IcM')?['statusCode']}",
+              "WorkflowRunId": "@{workflow()?['run']?['name']}",
+              "UpdatedUtc": "@{utcNow()}"
+            },
+            "headers": {
+              "Accept": "application/json;odata=nometadata",
+              "Content-Type": "application/json",
+              "If-Match": "*",
+              "x-ms-date": "@{utcNow('R')}",
+              "x-ms-version": "2019-02-02"
+            },
+            "method": "MERGE",
+            "uri": "@{concat(parameters('storageTableEndpoint'), parameters('storageTableName'), '(PartitionKey=''TeamsIcm'',RowKey=''', outputs('Compose_Row_Key'), ''')')}"
+          },
+          "runAfter": {
+            "Create_And_Parse_IcM": [
+              "Failed",
+              "TimedOut"
+            ]
+          }
+        },
+        "Reply_Provider_Failure": {
+          "type": "ApiConnection",
+          "inputs": {
+            "body": {
+              "messageBody": "<p>The IcM request failed. No successful incident creation was recorded. Please contact the .NET Engineering Services First Responder and include workflow run <code>@{workflow()?['run']?['name']}</code>.</p>",
+              "parentMessageId": "@{triggerBody()?['id']}",
+              "recipient": {
+                "groupId": "@{parameters('teamId')}",
+                "channelId": "@{parameters('channelId')}"
+              }
+            },
+            "host": {
+              "connection": {
+                "name": "@parameters('$connections')['teams']['connectionId']"
+              }
+            },
+            "method": "post",
+            "path": "/v1.0/teams/conversation/replyWithMessage/poster/@{encodeURIComponent('Flow bot')}/location/@{encodeURIComponent('Channel')}"
+          },
+          "runAfter": {
+            "Record_Provider_Failure": [
+              "Succeeded",
+              "Failed",
+              "TimedOut"
+            ]
+          }
+        },
+        "Stop_Provider_Failure": {
+          "type": "Terminate",
+          "inputs": {
+            "runStatus": "Failed",
+            "runError": {
+              "code": "IcmProviderFailed",
+              "message": "The ICM Provider did not create or update an incident."
+            }
+          },
+          "runAfter": {
+            "Reply_Provider_Failure": [
+              "Succeeded",
+              "Failed",
+              "TimedOut"
+            ]
+          }
+        },
+        "Record_Reply_Failure": {
+          "type": "Http",
+          "inputs": {
+            "authentication": {
+              "type": "ManagedServiceIdentity",
+              "audience": "https://storage.azure.com/"
+            },
+            "body": {
+              "PartitionKey": "TeamsIcm",
+              "RowKey": "@{outputs('Compose_Row_Key')}",
+              "Status": "Failed",
+              "FailureStage": "TeamsReply",
+              "IncidentId": "@{outputs('Compose_Incident_Id')}",
+              "WorkflowRunId": "@{workflow()?['run']?['name']}",
+              "UpdatedUtc": "@{utcNow()}"
+            },
+            "headers": {
+              "Accept": "application/json;odata=nometadata",
+              "Content-Type": "application/json",
+              "If-Match": "*",
+              "x-ms-date": "@{utcNow('R')}",
+              "x-ms-version": "2019-02-02"
+            },
+            "method": "MERGE",
+            "uri": "@{concat(parameters('storageTableEndpoint'), parameters('storageTableName'), '(PartitionKey=''TeamsIcm'',RowKey=''', outputs('Compose_Row_Key'), ''')')}"
+          },
+          "runAfter": {
+            "Reply_With_IcM_Link": [
+              "Failed",
+              "TimedOut"
+            ]
+          }
+        },
+        "Stop_Reply_Failure": {
+          "type": "Terminate",
+          "inputs": {
+            "runStatus": "Failed",
+            "runError": {
+              "code": "TeamsReplyFailed",
+              "message": "The incident was created, but the Teams reply was not posted."
+            }
+          },
+          "runAfter": {
+            "Record_Reply_Failure": [
+              "Succeeded",
+              "Failed",
+              "TimedOut"
+            ]
+          }
+        }
+      },
+      "else": {
+        "actions": {
+          "Record_Validation_Failure": {
+            "type": "Http",
+            "inputs": {
+              "authentication": {
+                "type": "ManagedServiceIdentity",
+                "audience": "https://storage.azure.com/"
+              },
+              "body": {
+                "PartitionKey": "TeamsIcm",
+                "RowKey": "@{outputs('Compose_Row_Key')}",
+                "Status": "Failed",
+                "FailureStage": "Validation",
+                "WorkflowRunId": "@{workflow()?['run']?['name']}",
+                "UpdatedUtc": "@{utcNow()}"
+              },
+              "headers": {
+                "Accept": "application/json;odata=nometadata",
+                "Content-Type": "application/json",
+                "If-Match": "*",
+                "x-ms-date": "@{utcNow('R')}",
+                "x-ms-version": "2019-02-02"
+              },
+              "method": "MERGE",
+              "uri": "@{concat(parameters('storageTableEndpoint'), parameters('storageTableName'), '(PartitionKey=''TeamsIcm'',RowKey=''', outputs('Compose_Row_Key'), ''')')}"
+            }
+          },
+          "Reply_With_Intake_Template": {
+            "type": "ApiConnection",
+            "inputs": {
+              "body": {
+                "messageBody": "<p>No IcM was created because the request is incomplete or uses an unsupported severity. Submit a new root message with non-empty values using this exact template:</p><pre>Title:\nWho/customer affected:\nImpact:\nAffected service/infrastructure:\nEvidence or build/job URL:\nRequested action:\nReporter:\nSeverity: 3 or 4</pre>",
+                "parentMessageId": "@{triggerBody()?['id']}",
+                "recipient": {
+                  "groupId": "@{parameters('teamId')}",
+                  "channelId": "@{parameters('channelId')}"
+                }
+              },
+              "host": {
+                "connection": {
+                  "name": "@parameters('$connections')['teams']['connectionId']"
+                }
+              },
+              "method": "post",
+              "path": "/v1.0/teams/conversation/replyWithMessage/poster/@{encodeURIComponent('Flow bot')}/location/@{encodeURIComponent('Channel')}"
+            },
+            "runAfter": {
+              "Record_Validation_Failure": [
+                "Succeeded",
+                "Failed",
+                "TimedOut"
+              ]
+            }
+          },
+          "Stop_Validation_Failure": {
+            "type": "Terminate",
+            "inputs": {
+              "runStatus": "Failed",
+              "runError": {
+                "code": "InvalidIntake",
+                "message": "The Teams message did not satisfy the structured intake contract."
+              }
+            },
+            "runAfter": {
+              "Reply_With_Intake_Template": [
+                "Succeeded",
+                "Failed",
+                "TimedOut"
+              ]
+            }
+          }
+        }
+      },
+      "runAfter": {
+        "Compose_Title": [
+          "Succeeded"
+        ],
+        "Compose_Who": [
+          "Succeeded"
+        ],
+        "Compose_Impact": [
+          "Succeeded"
+        ],
+        "Compose_Affected_Infrastructure": [
+          "Succeeded"
+        ],
+        "Compose_Evidence": [
+          "Succeeded"
+        ],
+        "Compose_Requested_Action": [
+          "Succeeded"
+        ],
+        "Compose_Reporter": [
+          "Succeeded"
+        ],
+        "Compose_Severity": [
+          "Succeeded"
+        ]
+      }
+    }
+  },
+  "outputs": {}
+}


### PR DESCRIPTION
## Summary

- Provision a disabled-by-default Consumption Logic App for the AB#12383 Teams intake pilot.
- Use managed identity for durable Azure Table state and the Test ICM Provider.
- Fix the IcM destination to connector `9bfe0f4f-4dcf-4033-94a3-f463e90baf04` and routing rule `DDFUNCustomerRequests`.
- Validate the structured intake contract and allow only Sev3/Sev4.
- Add recovery, diagnostics, and failed-run alerting.

## Safety

The workflow deploys disabled. It is enabled only after the Teams connection is authorized and the Logic App identity is deployed to the ICM Provider Test allowlist. The Test provider creates real production IcMs, so end-to-end validation will use one controlled Sev4 incident that is resolved immediately.

## Validation

- `az bicep build --file eng/deployment/teams-icm-pilot.bicep`
- Azure resource-group deployment validation and what-if.
- Disabled deployment completed in `dnceng-teams-icm-pilot`.

Tracking: https://dev.azure.com/dnceng/internal/_workitems/edit/12383
