### PR TITLE
Fix .NET SDK setup for deployment validation

### DIFF
--- a/eng/deploy.yaml
+++ b/eng/deploy.yaml
@@ -213,9 +213,9 @@ stages:
         versionSpec: 5.3.x
 
     - task: UseDotNet@2
-      displayName: Install .NET 8
+      displayName: Install .NET from global.json
       inputs:
-        version: 8.x
+        useGlobalJson: true
 
     - task: AzureCLI@2
       inputs:
@@ -236,9 +236,9 @@ stages:
       artifact: AzureDevOpsClient.PostDeploymentTests
 
     - task: UseDotNet@2
-      displayName: Install .NET 8
+      displayName: Install .NET from global.json
       inputs:
-        version: 8.x
+        useGlobalJson: true
 
     - task: AzureCLI@2
       inputs:


### PR DESCRIPTION
## Summary
- install the .NET SDK pinned by `global.json` for Secret Manager scenario tests
- apply the same SDK setup to Telemetry Managed Identity Auth tests
- remove the stale .NET 8 pins from both post-deployment validation jobs

## Why
[dnceng-ci run 20260901.1](https://dev.azure.com/dnceng/internal/_build/results?buildId=3063155&view=results) failed both validation jobs because `global.json` requires SDK `10.0.111` while the jobs installed only .NET 8. Both published test artifacts target `net10.0`.

## Validation
- `eng/deploy.yaml` parses successfully
- `git diff --check` passes
- the new setup matches existing `UseDotNet@2` / `useGlobalJson: true` usage in this pipeline

Azure DevOps work item: [#12415](https://dev.azure.com/dnceng/internal/_workitems/edit/12415)
